### PR TITLE
Removed 'x' from AzDo Resource Names

### DIFF
--- a/Example Configuration/ProjectPolicies/Project.yml
+++ b/Example Configuration/ProjectPolicies/Project.yml
@@ -9,7 +9,7 @@ variables: {
 resources:
 
   - name: Project
-    type: AzureDevOpsDsc/xAzDoProject
+    type: AzureDevOpsDsc/AzDoProject
     postExecutionScript: if ($Project_Ensure -eq 'Absent') { Stop-TaskProcessing }
     properties:
       projectName: $ProjectName
@@ -20,9 +20,9 @@ resources:
       Ensure: $( if ([string]::IsNullOrEmpty($Project_Ensure)) { 'Present' } else { $Project_Ensure } )
 
   - name: Project Services
-    type: AzureDevOpsDsc/xAzDoProjectServices
+    type: AzureDevOpsDsc/AzDoProjectServices
     dependsOn: 
-      - AzureDevOpsDsc/xAzDoProject/Project
+      - AzureDevOpsDsc/AzDoProject/Project
     properties:
       projectName: $ProjectName
       GitRepositories: $( if ([string]::IsNullOrEmpty($Project_Service_GitRepositories)) { 'disabled' } else { $Project_Service_GitRepositories } )

--- a/Example Configuration/ProjectPolicies/ProjectGitRepositories.yml
+++ b/Example Configuration/ProjectPolicies/ProjectGitRepositories.yml
@@ -7,11 +7,11 @@ variables: {
 resources:
 
   - name: Default Git Configuration Permissions
-    type: AzureDevOpsDsc/xAzDoGitPermission
+    type: AzureDevOpsDsc/AzDoGitPermission
     dependsOn:
-      - AzureDevOpsDsc/xAzDoProject/Project
-      - AzureDevOpsDsc/xAzDoProjectGroup/CON Readers
-      - AzureDevOpsDsc/xAzDoProjectGroup/CON Board Administrators
+      - AzureDevOpsDsc/AzDoProject/Project
+      - AzureDevOpsDsc/AzDoProjectGroup/CON Readers
+      - AzureDevOpsDsc/AzDoProjectGroup/CON Board Administrators
     properties:
       ProjectName: $ProjectName
       RepositoryName: $ProjectName

--- a/Example Configuration/ProjectPolicies/ProjectGroups.yml
+++ b/Example Configuration/ProjectPolicies/ProjectGroups.yml
@@ -12,9 +12,9 @@ variables: {
 resources:
 
   - name: CON Readers
-    type: AzureDevOpsDsc/xAzDoProjectGroup
+    type: AzureDevOpsDsc/AzDoProjectGroup
     dependsOn: 
-      - AzureDevOpsDsc/xAzDoProject/Project
+      - AzureDevOpsDsc/AzDoProject/Project
     properties:
       ProjectName: $ProjectName
       GroupName: $ProjectGroups_Role_CONReaders
@@ -22,9 +22,9 @@ resources:
 
   - name: CON Board Administrators
     condition: $ProjectWorkBoardsStatus -eq 'enabled'
-    type: AzureDevOpsDsc/xAzDoProjectGroup
+    type: AzureDevOpsDsc/AzDoProjectGroup
     dependsOn: 
-      - AzureDevOpsDsc/xAzDoProject/Project
+      - AzureDevOpsDsc/AzDoProject/Project
     properties:
       ProjectName: $ProjectName
       GroupName: $ProjectGroups_Role_CONBoardAdministrators

--- a/Example Configuration/Projects/Present/Magenta.yml
+++ b/Example Configuration/Projects/Present/Magenta.yml
@@ -11,19 +11,19 @@ variables: {
 resources:
 
 - name: Configuration Git Repository
-  type: AzureDevOpsDsc/xAzDoGitRepository
+  type: AzureDevOpsDsc/AzDoGitRepository
   dependsOn: 
-    - AzureDevOpsDsc/xAzDoProject/Project
+    - AzureDevOpsDsc/AzDoProject/Project
   properties:
     ProjectName: $ProjectName
     RepositoryName: $ProjectRepositoryName
 
 - name: Configuration Git Permissions
-  type: AzureDevOpsDsc/xAzDoGitPermission
+  type: AzureDevOpsDsc/AzDoGitPermission
   dependsOn: 
-    - AzureDevOpsDsc/xAzDoGitRepository/Configuration Git Repository
-    - AzureDevOpsDsc/xAzDoProjectGroup/CON Readers
-    - AzureDevOpsDsc/xAzDoProjectGroup/CON Board Administrators
+    - AzureDevOpsDsc/AzDoGitRepository/Configuration Git Repository
+    - AzureDevOpsDsc/AzDoProjectGroup/CON Readers
+    - AzureDevOpsDsc/AzDoProjectGroup/CON Board Administrators
   properties:
     ProjectName: $ProjectName
     RepositoryName: $ProjectRepositoryName

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This LCM utilizes Datum from Gael Colas to streamline configuration. For more in
     ```yaml
     - name: CON Board Administrators
       condition: $ProjectWorkBoardsStatus -eq 'enabled'
-      type: AzureDevOpsDsc/xAzDoProjectGroup
+      type: AzureDevOpsDsc/AzDoProjectGroup
       dependsOn:
-        - AzureDevOpsDsc/xAzDoProject/Project
+        - AzureDevOpsDsc/AzDoProject/Project
       properties:
         ProjectName: $ProjectName
         GroupName: $GroupName
@@ -63,7 +63,7 @@ The Local Configuration Manager (LCM) provides a set of features applicable to a
     ```yaml
     - name: CON Board Administrators
       condition: $ProjectWorkBoardsStatus -eq 'enabled'
-      type: AzureDevOpsDsc/xAzDoProjectGroup
+      type: AzureDevOpsDsc/AzDoProjectGroup
     ```
 
 - __postExecutionScript__: This feature triggers a script after the resource has been executed. It can be used to perform additional operations or clean-up tasks following the resource's execution. This is helpful for managing state changes or handling post-execution logic.
@@ -72,7 +72,7 @@ The Local Configuration Manager (LCM) provides a set of features applicable to a
 
     ```yaml
     - name: Project
-      type: AzureDevOpsDsc/xAzDoProject
+      type: AzureDevOpsDsc/AzDoProject
       postExecutionScript: if ($Project_Ensure -eq 'Absent') { Stop-TaskProcessing }
     ```
 
@@ -82,11 +82,11 @@ The Local Configuration Manager (LCM) provides a set of features applicable to a
 
     ```yaml
     - name: Default Git Configuration Permissions
-      type: AzureDevOpsDsc/xAzDoGitPermission
+      type: AzureDevOpsDsc/AzDoGitPermission
       dependsOn:
-        - AzureDevOpsDsc/xAzDoProject/Project
-        - AzureDevOpsDsc/xAzDoProjectGroup/CON Readers
-        - AzureDevOpsDsc/xAzDoProjectGroup/CON Board Administrators
+        - AzureDevOpsDsc/AzDoProject/Project
+        - AzureDevOpsDsc/AzDoProjectGroup/CON Readers
+        - AzureDevOpsDsc/AzDoProjectGroup/CON Board Administrators
     ```
 
 These features collectively enhance the robustness and adaptability of DSC resources managed by the LCM, allowing for more precise and context-sensitive configuration management.
@@ -99,7 +99,7 @@ In the realm of configuration, there are specialized commands designed to modify
 
     ```yaml
     - name: Project
-        type: AzureDevOpsDsc/xAzDoProject
+        type: AzureDevOpsDsc/AzDoProject
         postExecutionScript: if ($Project_Ensure -eq 'Absent') { Stop-TaskProcessing }
     ```
 

--- a/source/Public/Invoke-AZDoLCM.ps1
+++ b/source/Public/Invoke-AZDoLCM.ps1
@@ -190,7 +190,7 @@ function Invoke-AZDoLCM {
     postExecutionTask:
 
     - name: Org Group Members
-        type: AzureDevOpsDsc/xAzDoProject
+        type: AzureDevOpsDsc/AzDoProject
         properties:
         projectName: CON_$ProjectName
         projectDescription: $ProjectDescription


### PR DESCRIPTION
This pull request eliminates 'x' from the AzDO DSC Resource module to align it with the AzDo standards highlighted in [https://github.com/dsccommunity/AzureDevOpsDsc/pull/36](https://github.com/dsccommunity/AzureDevOpsDsc/pull/36).

> I noticed that the resources have ’x’ prefix, we can remove that as it is no longer used. We are actively trying to remove the ’x’ from module names and resources throughout the DSC Community. But it can be done in another PR too.
> 
> Impressive work on this one PR 😊
