### PR TITLE
Datum.Yaml Update - Add LCMConfigurationMode and YAML Based Change Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Stub/Partial Configuration: Enables merging of properties within the LCM at an elevated level for enhanced flexibility.
+- Added `executionMethodOverride` property to DSC-Based Resources.
+- Added Datum.yaml LCMConfigurationMode property. Introduced CaC Change Windows.
 
 ### Changed
 
-- LCM will perform an additional 'Test' after 'Set' to validate that setting has been applied correctly.
+- Replaced "Set" and "Test" modes with "ApplyOnly", "Audit", "Enforce" and "Scheduled"
+- Refactored DSC Resources to be classed-based.
 
 ### Fixed
 
 - Issues with Build script running on 'ubuntu-latest'. Issues with pwsh core handling classes.
 - Fixed Bugs within the Symantec Versioning script. Wasn't detecting tag versions.
+

--- a/Example Configuration/Datum.yml
+++ b/Example Configuration/Datum.yml
@@ -16,9 +16,22 @@ default_lookup_options: MostSpecific
 
 # Configuration and LCM Versioning Settings for the Configuration. This ensures that the right version of the LCM is used to apply the configuration.
 LCMConfigSettings:
-  ConfigurationVersion: 0.1
-  AZDOLCMVersion: 0.2
+  ConfigurationVersion: 0.2
+  AZDOLCMVersion: 0.3
   DSCResourceVersion: 2.0
+
+# Define the LCM Configuration Mode for the Datum Configuration.
+LCMConfigurationMode:
+  # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+  ConfigurationMode: Audit
+  # Define a Change Window Array that specifies when the configuration can be applied.
+  ChangeWindows:
+    - StartTime: '20:00' # Start of the change window. Time is in UTC.
+      EndTime: '24:00' # End of the change window. Time is in UTC.
+      ConfigurationMode: Audit # The configuration mode for this change window.
+    - StartTime: '00:00'
+      EndTime: '02:00'
+      ConfigurationMode: Enforce
 
 # Datum Handlers are used to process Datum values.
 DatumHandlers:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,49 @@ This LCM utilizes Datum from Gael Colas to streamline configuration. For more in
       DSCResourceVersion: 1.0
     ```
 
+1. __ConfigurationMode Change Windows__: Datum.yml includes settings that enable administrators to specify the ConfigurationMode and the associated change windows. Configuration Modes are:
+
+    - Audit: This mode allows for monitoring and reporting without making any changes to the system.
+    - Enforce: In this mode, the system actively applies the defined configurations, ensuring compliance.
+    - ApplyOnly: This mode applies the configurations but does not perform any auditing or enforcement actions.
+    - Scheduled: This mode allows configurations to be applied at specified times, providing flexibility in management.
+
+    Execution Precedence: The following hierarchy determines the order in which the `ConfigurationMode` is applied:
+
+    1. `Invoke-AZDoLCM -ConfigurationMode` Parameter. Setting this property will override the configuration.
+    1. `LCMConfigurationMode.LCMConfigurationMode`. Configuring this property will establish it as the default setting. The possible values are 'ApplyOnly', 'Audit', 'Enforce', and 'Scheduled'.
+    1. `LCMConfigurationMode.LCMConfigurationMode.ChangeWindows`. Setting up Change Windows will define the times in UTC when the LCM can operate in various modes. _If no change window is specified, it will revert to the default mode of 'Audit'. In cases of overlapping time windows, the first window will be chosen, and a warning will be issued._
+
+        ``` Text
+        [Get-LCMConfigurationMode] Current time 00:00 is within Change Window: 23:00 - 02:00. Setting LCM Configuration Mode to ApplyOnly.
+        [Get-LCMConfigurationMode] Overlapping Change Windows detected in Datum Configuration LCMConfigurationMode. The first matching window takes precedence.
+        ```
+
+        Change Window Syntax:
+
+        ```text
+        [ArrayList] ChangeWindows:
+            [String] StartTime: UTC StartTime
+            [String] EndTime: UTC EndTime
+            [String] ConfigurationMode: [Audit, Enforce, ApplyOnly]
+        ```
+
+      Example:
+
+      ```yaml
+      LCMConfigurationMode:
+          # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+          ConfigurationMode: Audit
+          # Define a Change Window Array that specifies when the configuration can be applied.
+          ChangeWindows:            
+              - StartTime: '20:00' # Start of the change window. Time is in UTC.
+              EndTime: '24:00' # End of the change window. Time is in UTC.
+              ConfigurationMode: Audit # The configuration mode for this change window.
+              - StartTime: '00:00'
+              EndTime: '02:00'
+              ConfigurationMode: Enforce
+      ```
+
 ### Enhanced LCM Resource Features
 
 The Local Configuration Manager (LCM) provides a set of features applicable to all Desired State Configuration (DSC) resources, enhancing their flexibility and control. These features include:
@@ -227,7 +270,7 @@ In the realm of configuration, there are specialized commands designed to modify
     ``` PowerShell
     #
     # Install Module Dependencies
-    Install-Module PSDesiredStateConfiguration, Datum, Datum.InvokeCommand -Force -Scope AllUsers -SkipPublisherCheck
+    Install-Module PSDesiredStateConfiguration, Datum, Datum.InvokeCommand, powershell-yaml -Force -Scope AllUsers -SkipPublisherCheck
     Write-Host "Installing Dependencies Modules"
 
     #
@@ -307,7 +350,9 @@ In the realm of configuration, there are specialized commands designed to modify
 
 1. __Setup the Azure DevOps Pipeline:__
 
-    __Template__:
+    __Template 1 - Classic__:
+
+    The classic template utilizes a pipeline approach to derive the ConfigurationMode:
 
     ``` YAML
       # Starter pipeline
@@ -332,9 +377,9 @@ In the realm of configuration, there are specialized commands designed to modify
       variables:
       - name: LCM_Method
         ${{ if eq(variables['Build.CronSchedule.DisplayName'], 'LCM Enforcement (Set)') }}:
-          value: 'Set'
+          value: 'Enforce'
         ${{ else }}:
-          value: 'Test'
+          value: 'Audit'
         readonly: true
 
       #container:
@@ -353,7 +398,49 @@ In the realm of configuration, there are specialized commands designed to modify
               exportConfigDir = 'C:\AzureDevOpsDSC\Configuration Export\'
               ConfigurationSourcePath = "$(build.sourcesDirectory)"
               JITToken = 'na'
-              Mode = "$(LCM_Method)"
+              ConfigurationMode = "$(LCM_Method)"
+              ReportPath = 'C:\AzureDevOpsDSC\Reporting\'
+            }
+            Invoke-AZDoLCM @params
+          displayName: Trigger the LCM
+          workingDirectory: "$(build.sourcesDirectory)"
+          errorActionPreference: continue
+    ```
+
+    __Template 2 - Updated__:
+
+    The classic template utilizes the internal datum configuration to derive the ConfigurationMode:
+
+    ``` YAML
+      # Starter pipeline
+      # Start with a minimal pipeline that you can customize to build and deploy your code.
+      # Add steps that build, run tests, deploy, and more:
+      # https://aka.ms/yaml
+
+      schedules: 
+        - cron: '0 05-20 * * 1-5'
+          displayName: Hourly LCM Check
+          always: true
+          branches:
+            include:
+            - master
+
+      #container:
+      pool:
+        name: azdo_dsc_lcm
+
+      steps:
+
+        - pwsh: |
+            Import-Module AzDO-DSC-LCM, AzureDevOpsDsc;
+            Write-Host "Source: $(build.sourcesDirectory)"
+            Write-Host "Method: $(LCM_Method)"
+
+            $params = @{
+              AzureDevopsOrganizationName = 'AzDoManagmentOrg'
+              exportConfigDir = 'C:\AzureDevOpsDSC\Configuration Export\'
+              ConfigurationSourcePath = "$(build.sourcesDirectory)"
+              JITToken = 'na'
               ReportPath = 'C:\AzureDevOpsDSC\Reporting\'
             }
             Invoke-AZDoLCM @params
@@ -364,8 +451,8 @@ In the realm of configuration, there are specialized commands designed to modify
 
     1. __Test to Ensure the LCM is Running Correctly:__
 
-    - __Set the LCM Mode to Test:__
-        - Switch the LCM to test mode to validate configuration changes without applying them immediately.
+    - __Set the LCM Mode to Audit:__
+        - Switch the LCM to Audit mode to validate configuration changes without applying them immediately.
     - __Look for Runtime Errors:__
         - Monitor logs and outputs for any runtime errors or warnings that could indicate misconfigurations or issues needing resolution.
     - __Verify Expected Outcomes:__

--- a/Tests/LCM/DSCConfiguration/Private/Configuration/Test-DatumConfiguration.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Private/Configuration/Test-DatumConfiguration.tests.ps1
@@ -23,10 +23,15 @@ Describe "Test-DatumConfiguration Function Tests" -Tag Unit, LCM, Configuration 
 
     }
 
-    Context "When Datum Configuration is Valid" {
+    Context "When testing LCMConfigSettings" {
+
         It "should pass without errors" {
             $datumConfig = @{
                 '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Audit'
+                        ChangeWindows = @()
+                    }
                     LCMConfigSettings = @{
                         ConfigurationVersion = "1.0.0"
                         AZDOLCMVersion = "1.0.0"
@@ -46,21 +51,29 @@ Describe "Test-DatumConfiguration Function Tests" -Tag Unit, LCM, Configuration 
 
             { Test-DatumConfiguration -Datum $datumConfig } | Should -Not -Throw
             Assert-MockCalled Write-Warning -Exactly 0
+
         }
-    }
- 
-    Context "When LCMConfigSettings is Missing" {
-        It "should throw an error" {
-            $datumConfig = @{}
+
+        It "should throw an error if LCMConfigSettings is missing" {
+            $datumConfig = @{
+                '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Audit'
+                        ChangeWindows = @()
+                    }
+                }
+            }
             { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw -ErrorId "*LCMConfigSettings*"
             Assert-MockCalled Write-Warning -Exactly 0
         }
-    }
 
-    Context "When Versions are Invalid" {
         It "should throw an error if version fields are not valid" {
             $datumConfig = @{
                 '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Audit'
+                        ChangeWindows = @()
+                    }                    
                     LCMConfigSettings = @{
                         ConfigurationVersion = "invalid"
                         AZDOLCMVersion = "1.0.0"
@@ -75,12 +88,14 @@ Describe "Test-DatumConfiguration Function Tests" -Tag Unit, LCM, Configuration 
             { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw -ErrorId "*valid version*"
             Assert-MockCalled Write-Warning -Exactly 0
         }
-    }
 
-    Context "When Datum Configuration Version is Out of Range" {
         It "should throw an error if version is outside the valid range" {
             $datumConfig = @{
                 '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Audit'
+                        ChangeWindows = @()
+                    }                    
                     LCMConfigSettings = @{
                         ConfigurationVersion = "3.0.0"
                         AZDOLCMVersion = "1.0.0"
@@ -96,14 +111,15 @@ Describe "Test-DatumConfiguration Function Tests" -Tag Unit, LCM, Configuration 
             { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw -ErrorId "*outside the valid range*"
             Assert-MockCalled Write-Warning -Exactly 0
         }
-    }
 
-    Context "When Datum Configuration Version is Outdated" {
         It "should issue a warning if two or more minor versions behind" {
-
 
             $datumConfig = @{
                 '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Audit'
+                        ChangeWindows = @()
+                    }                    
                     LCMConfigSettings = @{
                         ConfigurationVersion = "1.8.0"
                         AZDOLCMVersion = "1.0.0"
@@ -125,9 +141,6 @@ Describe "Test-DatumConfiguration Function Tests" -Tag Unit, LCM, Configuration 
             Assert-MockCalled Write-Warning -Exactly 1
 
         }
-    }
-
-    Context "When the PSDesiredStateConfiguration is Outdated" {
 
         it "Should throw an error if outside the valid range" {
 
@@ -135,6 +148,10 @@ Describe "Test-DatumConfiguration Function Tests" -Tag Unit, LCM, Configuration 
 
             $datumConfig = @{
                 '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Audit'
+                        ChangeWindows = @()
+                    }                    
                     LCMConfigSettings = @{
                         ConfigurationVersion = "1.0.0"
                         AZDOLCMVersion = "1.0.0"
@@ -154,6 +171,165 @@ Describe "Test-DatumConfiguration Function Tests" -Tag Unit, LCM, Configuration 
 
             Test-DatumConfiguration -Datum $datumConfig
             Assert-MockCalled Write-Warning -Exactly 0
+        }
+
+    }
+
+    Context "When testing LCMConfigurationMode" {
+
+        BeforeAll {
+            $ModuleConfigurationData = @{
+                YAMLConfigurationMinimumVersion = "0.9.0"
+                YAMLConfigurationMaximumVersion = "2.0.0"
+                PSDesiredStateConfigurationMinimumVersion = "1.0.0"
+                PSDesiredStateConfigurationMaximumVersion = "2.0.0"
+                DSCResourceMinimumVersion = "1.0.0"
+                DSCResourceMaximumVersion = "2.0.0"
+            }
+
+        }
+
+        It "should pass without errors" {
+            $datumConfig = @{
+                '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Audit'
+                        ChangeWindows = @()
+                    }
+                    LCMConfigSettings = @{
+                        ConfigurationVersion = "1.0.0"
+                        AZDOLCMVersion = "1.0.0"
+                        DSCResourceVersion = "1.0.0"
+                    }
+                }
+            }
+
+            { Test-DatumConfiguration -Datum $datumConfig } | Should -Not -Throw
+            Assert-MockCalled Write-Warning -Exactly 0
+
+        }
+
+        It "should throw an error if LCMConfigurationMode is missing" {
+            $datumConfig = @{
+                '__Definition' = @{
+                    LCMConfigSettings = @{
+                        ConfigurationVersion = "1.0.0"
+                        AZDOLCMVersion = "1.0.0"
+                        DSCResourceVersion = "1.0.0"
+                    }
+                }
+            }
+            { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw "*LCMConfigurationMode*"
+            Assert-MockCalled Write-Warning -Exactly 0
+        }
+
+        It "should throw an error if ConfigurationMode is invalid" {
+            $datumConfig = @{
+                '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'InvalidMode'
+                        ChangeWindows = @()
+                    }                    
+                    LCMConfigSettings = @{
+                        ConfigurationVersion = "1.0.0"
+                        AZDOLCMVersion = "1.0.0"
+                        DSCResourceVersion = "1.0.0"
+                    }
+                }
+            }
+            { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw "*The Datum Configuration LCMConfigurationMode ConfigurationMode property is not one of the allowed values:*"
+            Assert-MockCalled Write-Warning -Exactly 0
+        }
+
+        it "should throw an error if ChangeWindow ConfigurationMode is invalid" {
+            $datumConfig = @{
+                '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Scheduled'
+                        ChangeWindows = @(
+                            @{
+                                StartTime = "09:00"
+                                EndTime = "17:00"
+                                ConfigurationMode = 'InvalidMode'
+                            }
+                        )
+                    }                    
+                    LCMConfigSettings = @{
+                        ConfigurationVersion = "1.0.0"
+                        AZDOLCMVersion = "1.0.0"
+                        DSCResourceVersion = "1.0.0"
+                    }
+                }
+            }
+            { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw "*The ConfigurationMode property in each ChangeWindow of the Datum Configuration LCMConfigurationMode must be one of the allowed values*"
+            Assert-MockCalled Write-Warning -Exactly 0
+        }
+
+        it "should throw an error if ChangeWindow is missing required properties" {
+            $datumConfig = @{
+                '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Scheduled'
+                        ChangeWindows = @(
+                            @{
+                                StartTime = "09:00"
+                                # EndTime is missing
+                                ConfigurationMode = 'ApplyOnly'
+                            }
+                        )
+                    }                    
+                    LCMConfigSettings = @{
+                        ConfigurationVersion = "1.0.0"
+                        AZDOLCMVersion = "1.0.0"
+                        DSCResourceVersion = "1.0.0"
+                    }
+                }
+            }
+            { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw "*Each ChangeWindow in the Datum Configuration LCMConfigurationMode must contain StartTime, EndTime, and ConfigurationMode properties*"
+            Assert-MockCalled Write-Warning -Exactly 0
+        }
+
+        it "should throw an error if ChangeWindow StartTime or EndTime is invalid" {
+            $datumConfig = @{
+                '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        ConfigurationMode = 'Scheduled'
+                        ChangeWindows = @(
+                            @{
+                                StartTime = "9 AM"  # Invalid format
+                                EndTime = "17:00"
+                                ConfigurationMode = 'ApplyOnly'
+                            }
+                        )
+                    }                    
+                    LCMConfigSettings = @{
+                        ConfigurationVersion = "1.0.0"
+                        AZDOLCMVersion = "1.0.0"
+                        DSCResourceVersion = "1.0.0"
+                    }
+                }
+            }
+            { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw "*The StartTime and EndTime properties in the ChangeWindow*"
+            Assert-MockCalled Write-Warning -Exactly 0
+        }
+
+        It "should throw an error if ConfigurationMode property is missing" {
+            $datumConfig = @{
+                '__Definition' = @{
+                    LCMConfigurationMode = @{
+                        # ConfigurationMode property is missing
+                        ChangeWindows = @()
+                    }                    
+                    LCMConfigSettings = @{
+                        ConfigurationVersion = "1.0.0"
+                        AZDOLCMVersion = "1.0.0"
+                        DSCResourceVersion = "1.0.0"
+                    }
+                }
+            }
+            { Test-DatumConfiguration -Datum $datumConfig } | Should -Throw "*LCMConfigurationMode*"
+            Assert-MockCalled Write-Warning -Exactly 0
+
         }
 
     }

--- a/Tests/LCM/DSCConfiguration/Private/LCM/Get-LCMConfigurationMode.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Private/LCM/Get-LCMConfigurationMode.tests.ps1
@@ -1,0 +1,91 @@
+Describe "Get-LCMConfigurationMode Function Tests" -Tag Unit, LCM, Configuration {
+
+    BeforeAll {
+
+        # Load the functions to test
+        $preParseFilePath = (Get-FunctionPath 'Get-LCMConfigurationMode.ps1').FullName
+
+        . $preParseFilePath
+
+    }
+
+    Context "When the top-level ConfigurationMode is 'ApplyOnly', 'Audit', or 'Enforce'" {
+
+        BeforeAll {
+            $DatumConfigurationMode = @{
+                ConfigurationMode = 'ApplyOnly'
+            }
+        }
+
+        It "should return the ConfigurationMode as ApplyOnly" {
+            $result = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfigurationMode
+            $result | Should -Be 'ApplyOnly'
+        }
+
+        It "should return the ConfigurationMode as Audit" {
+            $DatumConfigurationMode.ConfigurationMode = 'Audit'
+            $result = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfigurationMode
+            $result | Should -Be 'Audit'
+        }
+
+        It "should return the ConfigurationMode as Enforce" {
+            $DatumConfigurationMode.ConfigurationMode = 'Enforce'
+            $result = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfigurationMode
+            $result | Should -Be 'Enforce'
+        }
+
+    }
+
+    Context "When the top-level ConfigurationMode is 'Scheduled'" {
+
+        BeforeAll {
+            $DatumConfigurationMode = @{
+                ConfigurationMode = 'Scheduled'
+                ChangeWindows = @(
+                    @{
+                        StartTime = '20:00'
+                        EndTime = '24:00'
+                        ConfigurationMode = 'Audit'
+                    },
+                    @{
+                        StartTime = '00:00'
+                        EndTime = '02:00'
+                        ConfigurationMode = 'Enforce'
+                    }
+                )
+            }
+        }
+
+        It "should return the correct ConfigurationMode based on current time within the first ChangeWindow" {
+            # Mock Get-Date to return a time within the first ChangeWindow
+            Mock -CommandName Get-Date -MockWith { 
+                return [DateTime]::ParseExact("2023-01-01T21:00:00Z", "yyyy-MM-ddTHH:mm:ssZ", $null)
+            }
+
+            $result = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfigurationMode
+            $result | Should -Be 'Audit'
+        }
+
+        It "should return the correct ConfigurationMode based on current time within the second ChangeWindow" {
+            # Mock Get-Date to return a time within the second ChangeWindow
+            Mock -CommandName Get-Date -MockWith { 
+                return [DateTime]::ParseExact("2023-01-01T01:00:00Z", "yyyy-MM-ddTHH:mm:ssZ", $null)
+            }
+
+            $result = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfigurationMode
+            $result | Should -Be 'Enforce'
+        }
+
+        It "should default to Audit when current time is outside all ChangeWindows" {
+            # Mock Get-Date to return a time outside all ChangeWindows
+            Mock -CommandName Get-Date -MockWith {
+                return [DateTime]::ParseExact("2023-01-01T15:00:00Z", "yyyy-MM-ddTHH:mm:ssZ", $null)
+            }
+
+            $result = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfigurationMode
+            $result | Should -Be 'Audit'
+        }
+
+    }
+
+}

--- a/Tests/LCM/DSCConfiguration/Private/LCM/Get-LCMConfigurationMode.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Private/LCM/Get-LCMConfigurationMode.tests.ps1
@@ -7,6 +7,8 @@ Describe "Get-LCMConfigurationMode Function Tests" -Tag Unit, LCM, Configuration
 
         . $preParseFilePath
 
+        Mock -CommandName Write-Host
+
     }
 
     Context "When the top-level ConfigurationMode is 'ApplyOnly', 'Audit', or 'Enforce'" {

--- a/Tests/LCM/DSCConfiguration/Private/LCM/Start-LCM.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Private/LCM/Start-LCM.tests.ps1
@@ -139,10 +139,10 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
 
         It 'should correctly load configuration file' {
             Mock -CommandName Invoke-CustomTask -MockWith { throw "mock error"}
-            { Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "C:\CompositeResource" } | Should -Throw "mock error"
+            { Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "C:\CompositeResource" -ConfigurationMode 'audit' } | Should -Throw "mock error"
         }
 
-    } 
+    }
 
     Context "when operating in different modes" {
 
@@ -154,17 +154,40 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
             $references.Clear()
         }
 
-        It "should operate in 'Test' mode by default" {
-            Mock -CommandName Invoke-DscResource -MockWith {
-                [PSCustomObject]@{ InDesiredState = $true; Message = "Tested successfully." }
-            }
+        It "Should apply no changes in 'Audit' mode when resource is in desired state" {
 
-            Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "mock-path"
+            Mock -CommandName Invoke-DscResource -MockWith {
+                [PSCustomObject]@{ InDesiredState = $true; Message = "No action taken." }
+            } -ParameterFilter { $Method -eq "Test" }
+            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" }
+
+            Start-LCM -FilePath "test.json" -ConfigurationMode "Audit" -DSCCompositeResourcePath "mock-path"
 
             Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Test" } -Exactly 1
+            Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" } -Exactly 0
+            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter { $Message -like "*Resource is in the desired state:*" } -Exactly 1
+            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter { $Message -like "No action taken as resource is already in the desired state*" } -Exactly 1
+            
         }
 
-        It "should apply changes in 'Set' mode" {
+        It "Should apply no changes in 'Audit' mode when resource is in not in the desired state" {
+
+            Mock -CommandName Invoke-DscResource -MockWith {
+                [PSCustomObject]@{ InDesiredState = $false; Message = "No action taken." }
+            } -ParameterFilter { $Method -eq "Test" }
+            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" }
+
+            Start-LCM -FilePath "test.json" -ConfigurationMode "Audit" -DSCCompositeResourcePath "mock-path"
+
+            Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Test" } -Exactly 1
+            Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" } -Exactly 0
+            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter { $Message -like "*Resource is NOT in the desired state*" } -Exactly 1
+            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter { $Message -like "No action taken as ExecutionMode is 'Test'*" } -Exactly 1
+            
+        }
+
+
+        It "should apply changes in 'Enforce' mode" {
 
             Mock -CommandName Invoke-DscResource -MockWith {
                 if ($Script:TestDSCResourceCounter -eq 0) {
@@ -176,7 +199,7 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
             } -ParameterFilter { $Method -eq "Test" }
             Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" }
 
-            Start-LCM -FilePath "test.json" -Mode "Set" -DSCCompositeResourcePath "mock-path"
+            Start-LCM -FilePath "test.json" -ConfigurationMode "Enforce" -DSCCompositeResourcePath "mock-path"
 
             Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Test" } -Exactly 2
             Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" } -Exactly 1
@@ -184,7 +207,23 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
             
         }
 
-        It "should fail if a resource throws an error attempting to apply changes in 'Set' mode" {
+        It "should apply changes in 'Enforce' mode, but not check again if the change was successful" {
+
+            Mock -CommandName Invoke-DscResource -MockWith {
+                [PSCustomObject]@{ InDesiredState = $false; Message = "Resource set to desired state." }
+            } -ParameterFilter { $Method -eq "Test" }
+            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" }
+
+            Start-LCM -FilePath "test.json" -ConfigurationMode "ApplyOnly" -DSCCompositeResourcePath "mock-path"
+
+            Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Test" } -Exactly 1
+            Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" } -Exactly 1
+            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter { $Message -like "*Executed 'Set' method to make changes:*" } -Exactly 1
+            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter { $Message -like "ConfigurationMode is 'ApplyOnly', applying changes without testing again*" } -Exactly 1
+            
+        }
+
+        It "should fail if a resource throws an error attempting to apply changes in 'Enforce' mode" {
             Mock -CommandName Write-Error
             Mock -CommandName Invoke-DscResource -MockWith {
                 [PSCustomObject]@{ InDesiredState = $false; Message = "Not in desired state." }
@@ -193,7 +232,7 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
                 throw "mock error"
             }
 
-            { Start-LCM -FilePath "test.json" -Mode "Set" -DSCCompositeResourcePath "mock-path" } | Should -Not -Throw
+            { Start-LCM -FilePath "test.json" -ConfigurationMode "Enforce" -DSCCompositeResourcePath "mock-path" } | Should -Not -Throw
             Assert-MockCalled -CommandName Write-Error -Times 1
 
         }
@@ -205,7 +244,7 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
             } -ParameterFilter { $Method -eq "Test" }
             Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" }
 
-            Start-LCM -FilePath "test.json" -Mode "Set" -DSCCompositeResourcePath "mock-path"
+            Start-LCM -FilePath "test.json" -ConfigurationMode "Enforce" -DSCCompositeResourcePath "mock-path"
 
             Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Test" } -Exactly 2
             Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Set" } -Exactly 1
@@ -246,11 +285,12 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
                 }
             }
 
-            Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "mock-path"
+            Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "mock-path" -ConfigurationMode "Enforce"
 
-            Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Test" } -Exactly 1
+            Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Test" } -Exactly 2
             Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Method -eq "Get" } -Exactly 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Message -eq "Tasks Skipped: 1" } -Exactly 1
+            Assert-MockCalled -CommandName Write-Verbose -ParameterFilter { $Message -like "Skipping resource due to 'Stop-TaskProcessing' being called*" } -Exactly 1
 
         } 
 
@@ -286,7 +326,7 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
                 }
             }
 
-            Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "mock-path"
+            Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "mock-path" -ConfigurationMode "Enforce"
 
             Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Property.prop1 -eq "value1" } -Exactly 0
             Assert-MockCalled -CommandName Invoke-DscResource -ParameterFilter { $Property.prop2 -eq "value2" } -Exactly 2
@@ -332,9 +372,9 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
 
             Mock -CommandName Write-Verbose
 
-            Start-LCM -FilePath "test.json" -Mode Set -DSCCompositeResourcePath "mock-path"
+            Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "mock-path" -ConfigurationMode "Enforce"
 
-            Assert-MockCalled -CommandName Invoke-DscResource -Exactly 2
+            Assert-MockCalled -CommandName Invoke-DscResource -Exactly 3
             Assert-MockCalled -CommandName Write-Verbose -Exactly 0 -ParameterFilter { $Message -like "Using custom execution method: None" }
         }
 
@@ -368,7 +408,7 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
 
             Mock -CommandName Write-Verbose
 
-            Start-LCM -FilePath "test.json" -Mode Set -DSCCompositeResourcePath "mock-path"
+            Start-LCM -FilePath "test.json" -ConfigurationMode "Enforce" -DSCCompositeResourcePath "mock-path"
 
             Assert-MockCalled -CommandName Invoke-DscResource -Exactly 2
             Assert-MockCalled -CommandName Write-Verbose -Exactly 1 -ParameterFilter { $Message -eq "Using custom execution method: Test" }
@@ -404,13 +444,13 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
 
             Mock -CommandName Write-Verbose
 
-            Start-LCM -FilePath "test.json" -Mode Set -DSCCompositeResourcePath "mock-path"
+            Start-LCM -FilePath "test.json" -ConfigurationMode "Enforce" -DSCCompositeResourcePath "mock-path"
 
-            Assert-MockCalled -CommandName Invoke-DscResource -Exactly 2
+            Assert-MockCalled -CommandName Invoke-DscResource -Exactly 3
             Assert-MockCalled -CommandName Write-Verbose -Exactly 1 -ParameterFilter { $Message -eq "Using custom execution method: Set" }
         }
 
-    } 
+    }
 
     Context "when handling report paths" {
 
@@ -428,26 +468,22 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
         }
 
         It "should generate a report if ReportPath is specified" {
-            Mock -CommandName Export-Csv -MockWith {}
+            Mock -CommandName Export-Csv
 
-            Start-LCM -FilePath "test.json" -ReportPath "C:\Reports" -DSCCompositeResourcePath "mock-path" 
-            Assert-MockCalled -CommandName Export-Csv -Exactly 1
+            Start-LCM -FilePath "test.json" -ReportPath "C:\Reports" -DSCCompositeResourcePath "mock-path" -ConfigurationMode "Enforce"
+            Assert-MockCalled -CommandName Export-Csv -Times 1
         }
 
         It "should not generate a report if ReportPath is not specified" {
-            Mock -CommandName Export-Csv -MockWith {}
+            Mock -CommandName Export-Csv
 
-            Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "mock-path"
+            Start-LCM -FilePath "test.json" -DSCCompositeResourcePath "mock-path" -ConfigurationMode "Enforce"
 
             Assert-MockCalled -CommandName Export-Csv -Exactly 0
         }
     } 
 
     Context "error handling and edge cases" {
-
-        It "should handle invalid Mode parameter" {
-            { Start-LCM -FilePath "test.json" -Mode "Invalid" -DSCCompositeResourcePath "mock-path" } | Should -Throw
-        }
 
         It "should print a non-terminating error when the LCM fails to set a resource" {
 
@@ -462,11 +498,11 @@ Describe "Start-LCM Function Tests" -Tag Unit, MockedClass {
             } -Verifiable
             Mock -CommandName Get-Content -MockWith { "---\nparameters: {}\nvariables: {}\nresources: []" }
 
-            { Start-LCM -FilePath "test.json" -Mode "Set" -DSCCompositeResourcePath "mock-path" } | Should -Not -Throw
+            { Start-LCM -FilePath "test.json" -ConfigurationMode "Enforce" -DSCCompositeResourcePath "mock-path" } | Should -Not -Throw
             Should -InvokeVerifiable
 
         }
-    } 
+    }
     
 }    
     

--- a/Tests/LCM/DSCConfiguration/Public/Invoke-AZDoLCM.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Public/Invoke-AZDoLCM.tests.ps1
@@ -154,6 +154,9 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
 
         BeforeAll {
             $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
+            mock -CommandName 'Get-ChildItem' -MockWith { @(
+                [PSCustomObject]@{ Fullname = "$TestDrive\mockConfig.yml" }
+            ) }
         }
 
         AfterAll {
@@ -161,9 +164,9 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
         }
 
         it "should call Start-LCM with the specified ConfigurationMode" {
-            Mock -CommandName 'Start-LCM' -Verifiable -MockWith { return $true }
+            Mock -CommandName 'Start-LCM' -MockWith { return $true } -Verifiable
             { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
-            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter { $Mode -eq 'Audit' }
+            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter {  $ConfigurationMode -eq 'Audit' }
             Should -InvokeVerifiable
         }
 
@@ -173,16 +176,17 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
             Should -Invoke 'Start-LCM' -Exactly 0
         }
 
-        it "should call 'import-yaml' and 'Get-LCMConfigurationMode' if ConfigurationMode is not provided" {
-            Mock -CommandName 'Import-Yaml' -Verifiable -MockWith { return @{ LCMConfigurationMode = @{ ConfigurationMode = 'Scheduled'; ChangeWindows = @() } } }
+        it "should call 'ConvertFrom-Yaml' and 'Get-LCMConfigurationMode' if ConfigurationMode is not provided" {
+            Mock -CommandName 'Get-Content' -Verifiable -MockWith { return "MOCKED CONTENT" }
+            Mock -CommandName 'ConvertFrom-Yaml' -Verifiable -MockWith { return @{ LCMConfigurationMode = @{ ConfigurationMode = 'Scheduled'; ChangeWindows = @() } } }
             Mock -CommandName 'Get-LCMConfigurationMode' -Verifiable -MockWith { return 'Audit' }
             Mock -CommandName 'Start-LCM' -Verifiable -MockWith { return $true }
 
             { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
 
-            Should -Invoke 'Import-Yaml' -Exactly 1
+            Should -Invoke 'ConvertFrom-Yaml' -Exactly 1
             Should -Invoke 'Get-LCMConfigurationMode' -Exactly 1
-            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter { $Mode -eq 'Audit' }
+            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter { $ConfigurationMode -eq 'Audit' }
 
             Should -InvokeVerifiable
         }

--- a/Tests/LCM/DSCConfiguration/Public/Invoke-AZDoLCM.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Public/Invoke-AZDoLCM.tests.ps1
@@ -10,6 +10,7 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
             (Get-FunctionPath 'Start-LCM.ps1')
             (Get-FunctionPath 'Build-DatumConfiguration.ps1')
             (Get-FunctionPath 'Clone-Repository.ps1')
+            (Get-FunctionPath 'Get-LCMConfigurationMode.ps1')
         ) | ForEach-Object {
             . $_.FullName
         }
@@ -53,12 +54,12 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
 
         It "Should throw an error if AZDODSC_CACHE_DIRECTORY environment variable is not set" {
             Remove-Item Env:AZDODSC_CACHE_DIRECTORY -ErrorAction SilentlyContinue
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -Mode "test" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script*"
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script*"
         }
 
         It "Should not throw an error if AZDODSC_CACHE_DIRECTORY environment variable is set" {
             $env:AZDODSC_CACHE_DIRECTORY = "SomePath"
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -Mode "test" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
         } 
     }
 
@@ -84,18 +85,18 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
         }
 
        It "Should create authentication provider with ManagedIdentity" {
-            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -Mode "test" -ConfigurationSourcePath $ConfigurationSourcePath
+            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath
             Assert-MockCalled -CommandName New-AzDoAuthenticationProvider -Exactly 1 -Scope It -ParameterFilter { $useManagedIdentity }
        }
 
        It "Should create authentication provider with PAT" {
             $PAT = Get-MockPATToken
-            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken $PAT -AuthenticationType "PAT" -PATToken $PAT -Mode "test" -ConfigurationSourcePath $ConfigurationSourcePath
+            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken $PAT -AuthenticationType "PAT" -PATToken $PAT -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath
             Assert-MockCalled -CommandName New-AzDoAuthenticationProvider -Exactly 1 -Scope It -ParameterFilter { $PersonalAccessToken -eq $PAT }
        }
 
        It "Should build datum configuration" {
-            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -Mode "test" -ConfigurationSourcePath $ConfigurationSourcePath
+            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath
             Assert-MockCalled -CommandName Build-DatumConfiguration -Exactly 1 -Scope It
        }
     }
@@ -114,7 +115,7 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
             Mock -CommandName 'Clone-Repository' -Verifiable -MockWith {
                 return '\mockPath'
             }
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -Mode "test" -ConfigurationSourcePath "http://mockGitRepo.com/repo"} | Should -Not -Throw
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath "http://mockGitRepo.com/repo"} | Should -Not -Throw
             Should -InvokeVerifiable
         }
 
@@ -124,7 +125,7 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
                 $path -eq $exportConfigDir
             } -Verifiable -MockWith { return $true }
 
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -Mode "test" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
             Should -Invoke 'Clone-Repository' -Exactly 0
             Should -InvokeVerifiable
             Should -Invoke 'Start-LCM' -Exactly 0
@@ -138,7 +139,7 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
                 $path -eq $ConfigurationSourcePath
             } -Verifiable -MockWith { return $false }
 
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -Mode "test" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*Invalid ConfigurationSourcePath*"
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*Invalid ConfigurationSourcePath*"
             Should -Invoke 'Clone-Repository' -Exactly 0
             Should -InvokeVerifiable
             Should -Invoke 'Start-LCM' -Exactly 0            
@@ -146,6 +147,45 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
         }
 
 
+
+    }
+
+    Context "When testing -ConfigurationMode" {
+
+        BeforeAll {
+            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
+        }
+
+        AfterAll {
+            $Env:AZDODSC_CACHE_DIRECTORY = $null
+        }
+
+        it "should call Start-LCM with the specified ConfigurationMode" {
+            Mock -CommandName 'Start-LCM' -Verifiable -MockWith { return $true }
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter { $Mode -eq 'Audit' }
+            Should -InvokeVerifiable
+        }
+
+        it "should throw an error if an invalid ConfigurationMode is provided" {
+            Mock -CommandName 'Start-LCM'
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "InvalidMode" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*Cannot validate argument on parameter 'ConfigurationMode'*"
+            Should -Invoke 'Start-LCM' -Exactly 0
+        }
+
+        it "should call 'import-yaml' and 'Get-LCMConfigurationMode' if ConfigurationMode is not provided" {
+            Mock -CommandName 'Import-Yaml' -Verifiable -MockWith { return @{ LCMConfigurationMode = @{ ConfigurationMode = 'Scheduled'; ChangeWindows = @() } } }
+            Mock -CommandName 'Get-LCMConfigurationMode' -Verifiable -MockWith { return 'Audit' }
+            Mock -CommandName 'Start-LCM' -Verifiable -MockWith { return $true }
+
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+
+            Should -Invoke 'Import-Yaml' -Exactly 1
+            Should -Invoke 'Get-LCMConfigurationMode' -Exactly 1
+            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter { $Mode -eq 'Audit' }
+
+            Should -InvokeVerifiable
+        }
 
     }
 

--- a/Tests/LCM/Intergration/TestCases/ConditionalProperty/Datum.yml
+++ b/Tests/LCM/Intergration/TestCases/ConditionalProperty/Datum.yml
@@ -9,6 +9,13 @@ DatumHandlersThrowOnError: true
 
 # Datum Handlers are used to process Datum values.
 default_lookup_options: MostSpecific
+# Define the LCM Configuration Mode for the Datum Configuration.
+
+LCMConfigurationMode:
+  # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+  ConfigurationMode: Audit
+  # Define a Change Window Array that specifies when the configuration can be applied.
+  ChangeWindows: []
 
 # Configuration and LCM Versioning Settings for the Configuration. This ensures that the right version of the LCM is used to apply the configuration.
 LCMConfigSettings:

--- a/Tests/LCM/Intergration/TestCases/CustomExecutionMethod#2/Datum.yml
+++ b/Tests/LCM/Intergration/TestCases/CustomExecutionMethod#2/Datum.yml
@@ -10,6 +10,12 @@ DatumHandlersThrowOnError: true
 # Datum Handlers are used to process Datum values.
 default_lookup_options: MostSpecific
 
+LCMConfigurationMode:
+  # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+  ConfigurationMode: Audit
+  # Define a Change Window Array that specifies when the configuration can be applied.
+  ChangeWindows: []
+
 # Configuration and LCM Versioning Settings for the Configuration. This ensures that the right version of the LCM is used to apply the configuration.
 LCMConfigSettings:
   ConfigurationVersion: 0.1

--- a/Tests/LCM/Intergration/TestCases/CustomExecutionMethod/Datum.yml
+++ b/Tests/LCM/Intergration/TestCases/CustomExecutionMethod/Datum.yml
@@ -10,6 +10,12 @@ DatumHandlersThrowOnError: true
 # Datum Handlers are used to process Datum values.
 default_lookup_options: MostSpecific
 
+LCMConfigurationMode:
+  # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+  ConfigurationMode: Audit
+  # Define a Change Window Array that specifies when the configuration can be applied.
+  ChangeWindows: []
+
 # Configuration and LCM Versioning Settings for the Configuration. This ensures that the right version of the LCM is used to apply the configuration.
 LCMConfigSettings:
   ConfigurationVersion: 0.1

--- a/Tests/LCM/Intergration/TestCases/StandardResources/Datum.yml
+++ b/Tests/LCM/Intergration/TestCases/StandardResources/Datum.yml
@@ -10,6 +10,12 @@ DatumHandlersThrowOnError: true
 # Datum Handlers are used to process Datum values.
 default_lookup_options: MostSpecific
 
+LCMConfigurationMode:
+  # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+  ConfigurationMode: Audit
+  # Define a Change Window Array that specifies when the configuration can be applied.
+  ChangeWindows: []
+
 # Configuration and LCM Versioning Settings for the Configuration. This ensures that the right version of the LCM is used to apply the configuration.
 LCMConfigSettings:
   ConfigurationVersion: 0.1

--- a/Tests/LCM/Intergration/TestCases/StopProcessing/Datum.yml
+++ b/Tests/LCM/Intergration/TestCases/StopProcessing/Datum.yml
@@ -10,6 +10,12 @@ DatumHandlersThrowOnError: true
 # Datum Handlers are used to process Datum values.
 default_lookup_options: MostSpecific
 
+LCMConfigurationMode:
+  # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+  ConfigurationMode: Audit
+  # Define a Change Window Array that specifies when the configuration can be applied.
+  ChangeWindows: []
+
 # Configuration and LCM Versioning Settings for the Configuration. This ensures that the right version of the LCM is used to apply the configuration.
 LCMConfigSettings:
   ConfigurationVersion: 0.1

--- a/Tests/LCM/Intergration/TestCases/StubResources/Datum.yml
+++ b/Tests/LCM/Intergration/TestCases/StubResources/Datum.yml
@@ -10,6 +10,12 @@ DatumHandlersThrowOnError: true
 # Datum Handlers are used to process Datum values.
 default_lookup_options: MostSpecific
 
+LCMConfigurationMode:
+  # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+  ConfigurationMode: Audit
+  # Define a Change Window Array that specifies when the configuration can be applied.
+  ChangeWindows: []
+
 # Configuration and LCM Versioning Settings for the Configuration. This ensures that the right version of the LCM is used to apply the configuration.
 LCMConfigSettings:
   ConfigurationVersion: 0.1

--- a/Tests/LCM/Intergration/Tests/Invoke-AZDoLCM.tests.ps1
+++ b/Tests/LCM/Intergration/Tests/Invoke-AZDoLCM.tests.ps1
@@ -55,7 +55,7 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
             AzureDevopsOrganizationName = 'mock-org'
             exportConfigDir = Join-Path $TestDrive -ChildPath 'Output'
             JITToken = 'mock'
-            Mode = 'test'
+            ConfigurationMode = 'test'
             ConfigurationSourcePath = $null
         }
 
@@ -78,6 +78,21 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
             Mock -CommandName Write-Verbose
             Mock -CommandName Write-Warning
 
+        }
+
+        AfterEach {
+            $params.ConfigurationMode = 'test'
+        }
+
+        It "Should not throw any errors when using 'StandardResources' test case" {
+            $params.ConfigurationSourcePath = Join-Path $TestDrive -ChildPath 'TestCases\StandardResources'
+            { Invoke-AZDoLCM @params } | Should -Not -Throw
+        }
+
+        It "Should not throw any errors when using 'StandardResources' test case with no ConfigurationMode parameter specified" {
+            $params.Remove('ConfigurationMode')
+            $params.ConfigurationSourcePath = Join-Path $TestDrive -ChildPath 'TestCases\StandardResources'
+            { Invoke-AZDoLCM @params } | Should -Not -Throw
         }
 
         It "Should not throw any errors when using 'StandardResources' test case" {
@@ -179,7 +194,7 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
 
         It "Should use the custom execution method for Test" {
 
-            $params.Mode = 'Set'
+            $params.ConfigurationMode = 'Set'
             $params.ReportPath = (Join-Path $TestDrive -ChildPath 'Reports')
             $params.ConfigurationSourcePath = Join-Path $TestDrive -ChildPath 'TestCases\CustomExecutionMethod'
 
@@ -198,7 +213,7 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
 
         It "Should not use the custom execution method for None" {
 
-            $params.Mode = 'Set'
+            $params.ConfigurationMode = 'Set'
             $params.ReportPath = (Join-Path $TestDrive -ChildPath 'Reports')
             $params.ConfigurationSourcePath = Join-Path $TestDrive -ChildPath 'TestCases\CustomExecutionMethod#2'
 

--- a/Tests/LCM/Intergration/Tests/Invoke-AZDoLCM.tests.ps1
+++ b/Tests/LCM/Intergration/Tests/Invoke-AZDoLCM.tests.ps1
@@ -44,9 +44,9 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
         
         # Mock Sucessfull Configuration Application
         Mock -CommandName Invoke-DscResource -ParameterFilter {
-            $Method -eq 'Audit'
+            $Method -eq 'Test'
         } -MockWith { 
-            return @{
+            return @{ 
                 InDesiredState = $true
             }
         }
@@ -194,31 +194,31 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
 
         It "Should use the custom execution method for Test" {
 
-            $params.ConfigurationMode = 'Set'
+            $params.ConfigurationMode = 'Audit'
             $params.ReportPath = (Join-Path $TestDrive -ChildPath 'Reports')
             $params.ConfigurationSourcePath = Join-Path $TestDrive -ChildPath 'TestCases\CustomExecutionMethod'
 
             #Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Set' } -MockWith { return @{} }
-            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Audit' } -MockWith { return @{ InDesiredState = $true } }
+            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Test' } -MockWith { return @{ InDesiredState = $true } }
             Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Set' } 
             Mock -CommandName Write-Verbose
 
             Invoke-AZDoLCM @params 
 
             Assert-MockCalled -CommandName Write-Verbose -Times 1 -ParameterFilter { $Message -eq "Using custom execution method: Test" }
-            Assert-MockCalled -CommandName Invoke-DscResource -Times 2 -ParameterFilter { $Method -eq 'Audit' }
+            Assert-MockCalled -CommandName Invoke-DscResource -Times 2 -ParameterFilter { $Method -eq 'Test' }
             Assert-MockCalled -CommandName Invoke-DscResource -Exactly 0 -ParameterFilter { $Method -eq 'Set' }
 
         }
 
         It "Should not use the custom execution method for None" {
 
-            $params.ConfigurationMode = 'Set'
+            $params.ConfigurationMode = 'Enforce'
             $params.ReportPath = (Join-Path $TestDrive -ChildPath 'Reports')
             $params.ConfigurationSourcePath = Join-Path $TestDrive -ChildPath 'TestCases\CustomExecutionMethod#2'
 
             #Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Set' } -MockWith { return @{} }
-            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Audit' } -MockWith { return @{ InDesiredState = $true } }
+            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Test' } -MockWith { return @{ InDesiredState = $true } }
             Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Set' } 
             Mock -CommandName Write-Verbose
 

--- a/Tests/LCM/Intergration/Tests/Invoke-AZDoLCM.tests.ps1
+++ b/Tests/LCM/Intergration/Tests/Invoke-AZDoLCM.tests.ps1
@@ -44,7 +44,7 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
         
         # Mock Sucessfull Configuration Application
         Mock -CommandName Invoke-DscResource -ParameterFilter {
-            $Method -eq 'Test'
+            $Method -eq 'Audit'
         } -MockWith { 
             return @{
                 InDesiredState = $true
@@ -55,7 +55,7 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
             AzureDevopsOrganizationName = 'mock-org'
             exportConfigDir = Join-Path $TestDrive -ChildPath 'Output'
             JITToken = 'mock'
-            ConfigurationMode = 'test'
+            ConfigurationMode = 'Audit'
             ConfigurationSourcePath = $null
         }
 
@@ -81,7 +81,7 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
         }
 
         AfterEach {
-            $params.ConfigurationMode = 'test'
+            $params.ConfigurationMode = 'Audit'
         }
 
         It "Should not throw any errors when using 'StandardResources' test case" {
@@ -199,14 +199,14 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
             $params.ConfigurationSourcePath = Join-Path $TestDrive -ChildPath 'TestCases\CustomExecutionMethod'
 
             #Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Set' } -MockWith { return @{} }
-            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Test' } -MockWith { return @{ InDesiredState = $true } }
+            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Audit' } -MockWith { return @{ InDesiredState = $true } }
             Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Set' } 
             Mock -CommandName Write-Verbose
 
             Invoke-AZDoLCM @params 
 
             Assert-MockCalled -CommandName Write-Verbose -Times 1 -ParameterFilter { $Message -eq "Using custom execution method: Test" }
-            Assert-MockCalled -CommandName Invoke-DscResource -Times 2 -ParameterFilter { $Method -eq 'Test' }
+            Assert-MockCalled -CommandName Invoke-DscResource -Times 2 -ParameterFilter { $Method -eq 'Audit' }
             Assert-MockCalled -CommandName Invoke-DscResource -Exactly 0 -ParameterFilter { $Method -eq 'Set' }
 
         }
@@ -218,7 +218,7 @@ Describe "Invoke-AZDoLCM Intergration Tests" -Tag Integration {
             $params.ConfigurationSourcePath = Join-Path $TestDrive -ChildPath 'TestCases\CustomExecutionMethod#2'
 
             #Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Set' } -MockWith { return @{} }
-            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Test' } -MockWith { return @{ InDesiredState = $true } }
+            Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Audit' } -MockWith { return @{ InDesiredState = $true } }
             Mock -CommandName Invoke-DscResource -ParameterFilter { $Method -eq 'Set' } 
             Mock -CommandName Write-Verbose
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,12 @@
+# The following script bootstraps the environment by installing necessary modules.
+
+# Install all the Dependencies needed for the AzDO-DSC-LCM module.
+# Check PowerShell Version
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    # Must be running on Windows if PowerShell version is less than 7
+    # Use winget to install PowerShell 7
+    winget install --id Microsoft.PowerShell --source winget
+    exit 1
+}
+
+Install-Module PSDesiredStateConfiguration, Datum, Datum.InvokeCommand, powershell-yaml, pester -Force -Scope AllUsers -SkipPublisherCheck

--- a/source/Private/Configuration/Get-HoursDifference.ps1
+++ b/source/Private/Configuration/Get-HoursDifference.ps1
@@ -1,0 +1,21 @@
+function Get-HoursDifference {
+    param (
+        [string]$StartTime,
+        [string]$EndTime
+    )
+
+    # Convert the time strings to DateTime objects for today's date
+    $date1 = [datetime]::ParseExact($StartTime, "HH:mm", $null)
+    $date2 = [datetime]::ParseExact($EndTime, "HH:mm", $null)
+
+    # Calculate the time difference
+    $timeDifference = $date2 - $date1
+
+    # If the time difference is negative, add 24 hours
+    if ($timeDifference.TotalHours -lt 0) {
+        $timeDifference = $timeDifference + [timespan]::FromHours(24)
+    }
+
+    # Output the total hours transpired
+    return $timeDifference.TotalHours
+}

--- a/source/Private/LCM/Get-LCMConfigurationMode.ps1
+++ b/source/Private/LCM/Get-LCMConfigurationMode.ps1
@@ -1,0 +1,9 @@
+function Get-LCMConfigurationMode {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DatumConfigurationMode
+    )
+
+    
+
+}

--- a/source/Private/LCM/Get-LCMConfigurationMode.ps1
+++ b/source/Private/LCM/Get-LCMConfigurationMode.ps1
@@ -1,9 +1,81 @@
+<#
+.SYNOPSIS
+    Determines the Local Configuration Manager (LCM) Configuration Mode based on the provided Datum Configuration.
+
+.DESCRIPTION
+    The Get-LCMConfigurationMode function calculates the LCM Configuration Mode for a given Datum Configuration object. It supports both static modes (ApplyOnly, Audit, Enforce) and a Scheduled mode that allows for time-based configuration changes.
+
+.PARAMETER DatumConfigurationMode
+    The Datum Configuration object that contains the LCMConfigurationMode property. This property can either be a static mode or a Scheduled mode with defined Change Windows.
+    Example of DatumConfigurationMode:
+
+    LCMConfigurationMode:
+        # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+        ConfigurationMode: Audit
+        # Define a Change Window Array that specifies when the configuration can be applied.
+        ChangeWindows:
+            - StartTime: '20:00' # Start of the change window. Time is in UTC.
+            EndTime: '24:00' # End of the change window. Time is in UTC.
+            ConfigurationMode: Audit # The configuration mode for this change window.
+            - StartTime: '00:00'
+            EndTime: '02:00'
+            ConfigurationMode: Enforce
+
+#>
 function Get-LCMConfigurationMode {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$DatumConfigurationMode
+        [HashTable]$DatumConfigurationMode
     )
 
+    <#
     
+    # Define the LCM Configuration Mode for the Datum Configuration.
+    LCMConfigurationMode:
+        # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
+        ConfigurationMode: Audit
+        # Define a Change Window Array that specifies when the configuration can be applied.
+        ChangeWindows:
+            - StartTime: '20:00' # Start of the change window. Time is in UTC.
+            EndTime: '24:00' # End of the change window. Time is in UTC.
+            ConfigurationMode: Audit # The configuration mode for this change window.
+            - StartTime: '00:00'
+            EndTime: '02:00'
+            ConfigurationMode: Enforce
+    #>
+
+    Write-Verbose "[Get-LCMConfigurationMode] Determining LCM Configuration Mode for Datum Configuration: $DatumConfigurationMode"
+
+    #
+    # Caculate the LCM Configuration Mode based on the Datum Configuration Mode
+    
+    # Set the top-level LCM Configuration Mode
+    if ($DatumConfigurationMode.ConfigurationMode -eq 'Scheduled') {        
+        
+        # Iterate through each Change Window to determine the current Configuration Mode based on the current time. If there are overlapping windows, the first one in the list takes precedence.
+        $CurrentTimeUTC = (Get-Date).ToUniversalTime().ToString('HH:mm')
+        $LCMConfigurationMode = 'Audit' # Default to Audit if no windows match
+        $isSet = $false
+
+        foreach ($ChangeWindow in $DatumConfigurationMode.ChangeWindows) {
+            if ($CurrentTimeUTC -ge $ChangeWindow.StartTime -and $CurrentTimeUTC -lt $ChangeWindow.EndTime) {
+
+                Write-Host "[Get-LCMConfigurationMode] Current time $CurrentTimeUTC is within Change Window: $($ChangeWindow.StartTime) - $($ChangeWindow.EndTime). Setting LCM Configuration Mode to $($ChangeWindow.ConfigurationMode)."
+
+                if ($isSet) {
+                    Write-Warning "[Get-LCMConfigurationMode] Overlapping Change Windows detected in Datum Configuration LCMConfigurationMode. The first matching window takes precedence."
+                }
+
+                $isSet = $true
+                $LCMConfigurationMode = $ChangeWindow.ConfigurationMode                
+            }
+        }
+
+    } else {
+        # For non-scheduled modes, set the LCM Configuration Mode to the specified mode. Please note that the configuration was validated earlier.
+        $LCMConfigurationMode = $DatumConfigurationMode.ConfigurationMode
+    }
+
+    return $LCMConfigurationMode
 
 }

--- a/source/Private/LCM/Start-LCM.ps1
+++ b/source/Private/LCM/Start-LCM.ps1
@@ -188,8 +188,13 @@ function Start-LCM {
         # If not in the desired state and Mode is 'Set', execute the 'Set' method to apply changes
         if ($result.InDesiredState) {
             Write-Verbose "Resource is in the desired state: [$($task.type)/$($task.name)]"
+            Write-Verbose "No action taken as resource is already in the desired state: [$($task.type)/$($task.name)]"
+        } elseif ($ExecutionMode -eq "Test") {
+            Write-Verbose "Resource is NOT in the desired state and ExecutionMode is 'Test': [$($task.type)/$($task.name)]"
+            Write-Verbose "No action taken as ExecutionMode is 'Test': [$($task.type)/$($task.name)]"
         }
-        elseif ($ExecutionMode -eq "Set") {
+        elseif ($ExecutionMode -eq "Set")
+        {
 
             try {
                 # Execute the 'Set' method to make changes
@@ -215,7 +220,7 @@ function Start-LCM {
                 })
             }
         }
-
+    
         # If the task is in 'Continue' state, however the configuration mode is 'ApplyOnly' or 'Enforce', handle the execution accordingly
         if (($CurrentTaskState -eq 'Continue') -and ($ConfigurationMode -eq "ApplyOnly") -and ($ExecutionMode -eq "Set")) {
 

--- a/source/Private/LCM/Start-LCM.ps1
+++ b/source/Private/LCM/Start-LCM.ps1
@@ -37,17 +37,27 @@ function Start-LCM {
     param (
         [Parameter(Mandatory = $true)]
         [string] $FilePath, # The path to the configuration file (.yaml/.yml or .json)
-        [ValidateSet("Test", "Set")] # Ensures that Mode can only be 'Test' or 'Set'
-        [string] $Mode = "Test", # Default mode is 'Test', can be set to 'Set' for applying changes,
-        [String] $ReportPath = $null, # Optional parameter for specifying a report path
         [Parameter(Mandatory = $true)]
-        [String] $DSCCompositeResourcePath
+        [ValidateSet("ApplyOnly", "Audit", "Enforce")] # Ensures that ConfigurationMode can only be one of the specified values
+        [string] $ConfigurationMode, # The mode of operation for the LCM (e.g., ApplyOnly, Audit, Enforce, Scheduled)
+        [string] $ReportPath = $null, # Optional parameter for specifying a report path
+        [Parameter(Mandatory = $true)]
+        [string] $DSCCompositeResourcePath
     )
 
     # Clear StopTaskProcessing variable
     $script:StopTaskProcessing = $false
     $references.Clear()
     
+    $Mode = $( switch ($ConfigurationMode) {
+        "ApplyOnly" { "Set" }
+        "Audit" { "Test" }
+        "Enforce" { "Set" }
+        default { "Test" } # Default to Test if no match
+    })
+
+    Write-Verbose "Configuration Mode: $ConfigurationMode, Execution Mode: $Mode"
+
     $reporting = [System.Collections.Generic.List[PSCustomObject]]::New()
 
     $pipeline = [DSCConfigurationFile]::New($FilePath, $DSCCompositeResourcePath)
@@ -172,6 +182,9 @@ function Start-LCM {
             $ExecutionMode = $task.executionMethodOverride
         }
 
+        # Set Execution Processing Mode
+        $CurrentTaskState = 'Continue'
+
         # If not in the desired state and Mode is 'Set', execute the 'Set' method to apply changes
         if ($result.InDesiredState) {
             Write-Verbose "Resource is in the desired state: [$($task.type)/$($task.name)]"
@@ -183,7 +196,46 @@ function Start-LCM {
                 $resourceParameters.Method = "Set"
                 $setResult = Invoke-DscResource @resourceParameters
                 Write-Verbose "Executed 'Set' method to make changes: [$($task.type)/$($task.name)]"
+            } catch {
+                # If the 'Set' method fails, log the error and continue
+                Write-Error "Failed to apply changes with 'Set' method: [$($task.type)/$($task.name)]"
+                $CurrentTaskState = 'Stop'
 
+                $Message = $_.Exception.Message
+                $Result = "FAIL"
+
+                $reporting.Add([PSCustomObject]@{
+                    Counter     = $TaskCounter
+                    Name        = $task.name
+                    Type        = $task.type
+                    Status      = "Set"
+                    Method      = "SET"
+                    Result      = "FAIL"
+                    Message     = $_.Exception.Message
+                })
+            }
+        }
+
+        # If the task is in 'Continue' state, however the configuration mode is 'ApplyOnly' or 'Enforce', handle the execution accordingly
+        if (($CurrentTaskState -eq 'Continue') -and ($ConfigurationMode -eq "ApplyOnly") -and ($ExecutionMode -eq "Set")) {
+
+            # If the configuration mode is 'ApplyOnly', apply the changes without testing again
+            Write-Verbose "ConfigurationMode is 'ApplyOnly', applying changes without testing again: [$($task.type)/$($task.name)]"
+            # Update the reporting list
+            $null = $reporting.Add([PSCustomObject]@{
+                Counter     = $TaskCounter
+                Name        = $task.name
+                Type        = $task.type
+                Status      = "Set"
+                Method      = "SET"
+                Result      = "PASS"
+                Message     = "Resource set to desired state in 'ApplyOnly' mode."
+            })
+
+        } elseif (($CurrentTaskState -eq 'Continue') -and ($ConfigurationMode -eq "Enforce") -and ($ExecutionMode -eq "Set")) {
+
+            # If the configuration mode is 'Enforce', we need to ensure the resource is in the desired state
+            try {
                 # Retest the resource to ensure the changes were applied successfully
                 $resourceParameters.Method = "Test"
                 $result = Invoke-DscResource @resourceParameters
@@ -200,28 +252,23 @@ function Start-LCM {
                     Write-Verbose "Failed to set resource to desired state: [$($task.type)/$($task.name)]"
                 }
 
-            }
-            catch {
+            } catch {
                 Write-Error "Failed to apply changes with 'Set' method: [$($task.type)/$($task.name)]"
                 $Message = $_.Exception.Message
                 $Result = "FAIL"
             }
-            finally {
-                # Update the reporting list with the result of the 'Set' operation
-                $null = $reporting.Add([PSCustomObject]@{
-                    Counter     = $TaskCounter
-                    Name        = $task.name
-                    Type        = $task.type
-                    Status      = "Set"
-                    Method      = "SET"
-                    Result      = $Result
-                    Message     = $Message
-                })
+
+            # Update the reporting list with the result of the 'Set' operation
+            $null = $reporting.Add([PSCustomObject]@{
+                Counter     = $TaskCounter
+                Name        = $task.name
+                Type        = $task.type
+                Status      = "Set"
+                Method      = "SET"
+                Result      = $Result
+                Message     = $Message
+            })
             
-            }
-        }
-        else {
-            Write-Verbose "Change needed, but mode is not set to 'Set': [$($task.type)/$($task.name)]"
         }
 
         #
@@ -244,7 +291,6 @@ function Start-LCM {
         Write-Verbose "Stored output of 'Get' operation in references table for resource: [$($task.type)/$($task.name)]"
 
     }
-
 
     #
     # Report the results of the DSC Configuration

--- a/source/Public/Invoke-AZDoLCM.ps1
+++ b/source/Public/Invoke-AZDoLCM.ps1
@@ -17,8 +17,8 @@ Specifies the URL or directory path for the configuration source. This parameter
 .PARAMETER JITToken
 Specifies the Just-In-Time (JIT) access token. This parameter is mandatory.
 
-.PARAMETER Mode
-Specifies the mode of operation. Valid values are 'Test' and 'Set'. The default value is 'Test'.
+.PARAMETER ConfigurationMode
+Specifies the Local Configuration Manager (LCM) mode to use. Valid values are 'ApplyOnly', 'Audit', and 'Enforce'. This parameter is optional; if not provided, the mode will be determined from the Datum configuration.
 
 .PARAMETER AuthenticationType
 Specifies the authentication type to use. Valid values are 'ManagedIdentity' and 'PAT'. The default value is 'ManagedIdentity'.
@@ -68,10 +68,11 @@ function Invoke-AzDoLCM {
 
         # Declares an optional parameter with a ValidateSet attribute to restrict the value to either 'Test' or 'Set'.
         # The default value for this parameter is 'Set'.
-        [Parameter(Mandatory, ParameterSetName='Default')]
-        [Parameter(Mandatory, ParameterSetName='PAT')]
-        [ValidateSet('Test', 'Set')]
-        [String]$Mode='Test',
+        [Parameter(ParameterSetName='Default')]
+        [Parameter(ParameterSetName='PAT')]
+        [ValidateSet("ApplyOnly", "Audit", "Enforce")]
+        [AllowEmptyString()]
+        [String]$ConfigurationMode,
 
         # Declare the AuthenticationType parameter with a ValidateSet attribute to restrict the value to 'ManagedIdentity' or 'PAT'.
         # The default value for this parameter is 'ManagedIdentity'.
@@ -141,11 +142,20 @@ function Invoke-AzDoLCM {
     #}
 
     #
+    # Determine the LCM Configuration Mode
+
+    # If the ConfigurationMode parameter is provided, use it. Otherwise, determine the mode from the Datum Configuration.
+    if (-not $ConfigurationMode) {
+        $DatumConfiguration = Get-Content -Path (Join-Path $DatumConfigurationPath 'datum.yml') | ConvertFrom-Yaml
+        $ConfigurationMode = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfiguration.LCMConfigurationMode
+    }
+
+    #
     # Invoke the Resources
 
     # Create a hashtable to store the parameters
     $params = @{
-        Mode = $Mode
+        ConfigurationMode = $ConfigurationMode
         DSCCompositeResourcePath = Join-Path $DatumConfigurationPath 'CompositeResources'
     }
 

--- a/source/Public/Test-DatumConfiguration.ps1
+++ b/source/Public/Test-DatumConfiguration.ps1
@@ -46,7 +46,7 @@ function Test-DatumConfiguration {
     }
 
     # Permitted values for ConfigurationMode are: ApplyOnly, Audit, Enforce, Scheduled
-    if (-not $allowedConfigurationModes -contains $Datum.__Definition.LCMConfigurationMode.ConfigurationMode) {
+    if ($allowedConfigurationModes -notcontains $Datum.__Definition.LCMConfigurationMode.ConfigurationMode) {
         throw "[Test-DatumConfiguration] The Datum Configuration LCMConfigurationMode ConfigurationMode property is not one of the allowed values: $($allowedConfigurationModes -join ', '). The Datum Configuration is invalid and cannot be processed."
     }
 
@@ -61,7 +61,7 @@ function Test-DatumConfiguration {
             throw "[Test-DatumConfiguration] Each ChangeWindow in the Datum Configuration LCMConfigurationMode must contain StartTime, EndTime, and ConfigurationMode properties. The Datum Configuration is invalid and cannot be processed."
         }
         # Permitted values for ConfigurationMode in ChangeWindows are: ApplyOnly, Audit, Enforce
-        if (-not $allowedChangeWindowConfigurationModes -contains $ChangeWindow.ConfigurationMode) {
+        if ($allowedChangeWindowConfigurationModes -notcontains $ChangeWindow.ConfigurationMode) {
             throw "[Test-DatumConfiguration] The ConfigurationMode property in each ChangeWindow of the Datum Configuration LCMConfigurationMode must be one of the allowed values: $($allowedChangeWindowConfigurationModes -join ', '). The Datum Configuration is invalid and cannot be processed."
         }
         # Validate that Start and End are time strings are in the correct 24-hour format.

--- a/source/Public/Test-DatumConfiguration.ps1
+++ b/source/Public/Test-DatumConfiguration.ps1
@@ -33,6 +33,9 @@ function Test-DatumConfiguration {
     # Validate the LCMConfigurationMode Configuration
     #
 
+    $allowedChangeWindowConfigurationModes = @('ApplyOnly', 'Audit', 'Enforce')
+    $allowedConfigurationModes = @('ApplyOnly', 'Audit', 'Enforce', 'Scheduled')
+    
     if ($null -eq $Datum.__Definition.LCMConfigurationMode) {
         throw "[Test-DatumConfiguration] The Datum Configuration does not contain the LCMConfigurationMode property. The Datum Configuration is invalid and cannot be processed."
     }
@@ -41,6 +44,12 @@ function Test-DatumConfiguration {
     if (-not $Datum.__Definition.LCMConfigurationMode.ContainsKey('ConfigurationMode')) {
         throw "[Test-DatumConfiguration] The Datum Configuration LCMConfigurationMode does not contain the ConfigurationMode property. The Datum Configuration is invalid and cannot be processed."
     }
+
+    # Permitted values for ConfigurationMode are: ApplyOnly, Audit, Enforce, Scheduled
+    if (-not $allowedConfigurationModes -contains $Datum.__Definition.LCMConfigurationMode.ConfigurationMode) {
+        throw "[Test-DatumConfiguration] The Datum Configuration LCMConfigurationMode ConfigurationMode property is not one of the allowed values: $($allowedConfigurationModes -join ', '). The Datum Configuration is invalid and cannot be processed."
+    }
+
     # Validate that the ConfigurationMode is one of the allowed values.
     if (-not $Datum.__Definition.LCMConfigurationMode.ContainsKey('ChangeWindows')) {
         throw "[Test-DatumConfiguration] The Datum Configuration LCMConfigurationMode does not contain the ChangeWindows property. The Datum Configuration is invalid and cannot be processed."
@@ -50,6 +59,10 @@ function Test-DatumConfiguration {
     ForEach ($ChangeWindow in $Datum.__Definition.LCMConfigurationMode.ChangeWindows) {
         if (-not $ChangeWindow.ContainsKey('StartTime') -or -not $ChangeWindow.ContainsKey('EndTime') -or -not $ChangeWindow.ContainsKey('ConfigurationMode')) {
             throw "[Test-DatumConfiguration] Each ChangeWindow in the Datum Configuration LCMConfigurationMode must contain StartTime, EndTime, and ConfigurationMode properties. The Datum Configuration is invalid and cannot be processed."
+        }
+        # Permitted values for ConfigurationMode in ChangeWindows are: ApplyOnly, Audit, Enforce
+        if (-not $allowedChangeWindowConfigurationModes -contains $ChangeWindow.ConfigurationMode) {
+            throw "[Test-DatumConfiguration] The ConfigurationMode property in each ChangeWindow of the Datum Configuration LCMConfigurationMode must be one of the allowed values: $($allowedChangeWindowConfigurationModes -join ', '). The Datum Configuration is invalid and cannot be processed."
         }
         # Validate that Start and End are time strings are in the correct 24-hour format.
         if (-not $ChangeWindow.StartTime -match '^\d{2}:\d{2}$' -or -not $ChangeWindow.EndTime -match '^\d{2}:\d{2}$') {

--- a/source/Public/Test-DatumConfiguration.ps1
+++ b/source/Public/Test-DatumConfiguration.ps1
@@ -27,7 +27,58 @@ function Test-DatumConfiguration {
         $Datum
     )
 
-    Write-Verbose "[Test-DatumConfiguration] Validating the Datum Configuration."
+    Write-Verbose "[Test-DatumConfiguration] Validating the Datum (datum.yml) Configuration."
+
+    #
+    # Validate the LCMConfigurationMode Configuration
+    #
+
+    if ($null -eq $Datum.__Definition.LCMConfigurationMode) {
+        throw "[Test-DatumConfiguration] The Datum Configuration does not contain the LCMConfigurationMode property. The Datum Configuration is invalid and cannot be processed."
+    }
+
+    # Validate that the LCMConfigurationMode contains the required properties.
+    if (-not $Datum.__Definition.LCMConfigurationMode.ContainsKey('ConfigurationMode')) {
+        throw "[Test-DatumConfiguration] The Datum Configuration LCMConfigurationMode does not contain the ConfigurationMode property. The Datum Configuration is invalid and cannot be processed."
+    }
+    # Validate that the ConfigurationMode is one of the allowed values.
+    if (-not $Datum.__Definition.LCMConfigurationMode.ContainsKey('ChangeWindows')) {
+        throw "[Test-DatumConfiguration] The Datum Configuration LCMConfigurationMode does not contain the ChangeWindows property. The Datum Configuration is invalid and cannot be processed."
+    }
+
+    # Validate the properties of the ChangeWindows array.
+    ForEach ($ChangeWindow in $Datum.__Definition.LCMConfigurationMode.ChangeWindows) {
+        if (-not $ChangeWindow.ContainsKey('StartTime') -or -not $ChangeWindow.ContainsKey('EndTime') -or -not $ChangeWindow.ContainsKey('ConfigurationMode')) {
+            throw "[Test-DatumConfiguration] Each ChangeWindow in the Datum Configuration LCMConfigurationMode must contain StartTime, EndTime, and ConfigurationMode properties. The Datum Configuration is invalid and cannot be processed."
+        }
+        # Validate that Start and End are time strings are in the correct 24-hour format.
+        if (-not $ChangeWindow.StartTime -match '^\d{2}:\d{2}$' -or -not $ChangeWindow.EndTime -match '^\d{2}:\d{2}$') {
+            throw "[Test-DatumConfiguration] The StartTime and EndTime properties in the ChangeWindow must be in the format HH:mm (24-hour format). The Datum Configuration is invalid and cannot be processed."
+        }
+        # Ensure that the StartTime and EndTime are in 24-hour format.
+        try {
+            $startTime = [datetime]::ParseExact($ChangeWindow.StartTime, "HH:mm", $null)
+            $endTime = [datetime]::ParseExact($ChangeWindow.EndTime, "HH:mm", $null)
+        } catch {
+            throw "[Test-DatumConfiguration] The StartTime and EndTime properties in the ChangeWindow must be valid time strings in the format HH:mm (24-hour format). The Datum Configuration is invalid and cannot be processed."
+        }
+    }
+    
+    # Validate that the ConfigurationMode is one of the allowed values.
+    $allowedConfigurationModes = @('ApplyOnly', 'Audit', 'Enforce', 'Scheduled')
+    if ($Datum.__Definition.LCMConfigurationMode.ConfigurationMode -and 
+        -not $allowedConfigurationModes -contains $Datum.__Definition.LCMConfigurationMode.ConfigurationMode) {
+        throw "[Test-DatumConfiguration] The Datum Configuration LCMConfigurationMode ConfigurationMode property is not one of the allowed values: $($allowedConfigurationModes -join ', '). The Datum Configuration is invalid and cannot be processed."
+    }
+    # Ensure that ChangeWindows contains at least one entry if ConfigurationMode is 'Scheduled'.
+    if ($Datum.__Definition.LCMConfigurationMode.ConfigurationMode -eq 'Scheduled' -and 
+        -not $Datum.__Definition.LCMConfigurationMode.ChangeWindows.Count -ne 0) {
+        throw "[Test-DatumConfiguration] The Datum Configuration LCMConfigurationMode ChangeWindows property must contain at least one entry when the ConfigurationMode is 'Scheduled'. The Datum Configuration is invalid and cannot be processed."
+    }
+    
+    #
+    # LCM Configuration Versioning
+    #
 
     # Validate that the Datum Configuration meets the requirements for the Datum Configuration.
     if ($null -eq $Datum.__Definition.LCMConfigSettings) {


### PR DESCRIPTION
Description:

This pull request introduces updates to the Datum.yaml configuration file to enhance the system's configuration capabilities. The following changes have been made:

- Added LCMConfigurationMode:
    Introduced a new parameter, LCMConfigurationMode, to specify the mode of the LCM configuration. This allows for better control over how configurations are applied and managed within the system.
- Implemented YAML Based Change Windows:
  Added support for defining change windows in a YAML format. This feature enables users to specify time frames during which changes can be applied, improving the scheduling and management of updates.

Datum.yml
``` YAML
# Define the LCM Configuration Mode for the Datum Configuration.
LCMConfigurationMode:
  # The LCM Configuration Mode can be one of the following: ApplyOnly, Audit, Enforce, Scheduled
  ConfigurationMode: Audit
  # Define a Change Window Array that specifies when the configuration can be applied.
  ChangeWindows:
    - StartTime: '20:00' # Start of the change window. Time is in UTC.
      EndTime: '24:00' # End of the change window. Time is in UTC.
      ConfigurationMode: Audit # The configuration mode for this change window.
    - StartTime: '00:00'
      EndTime: '02:00'
      ConfigurationMode: Enforce
```

Pipeline Amendments. Set and Test have been replaced by: `ApplyOnly`, `Audit`, `Enforce` and `Scheduled`

Refer to Readme.md for documentation.

