### PR TITLE
Extract Invoke-DscLCM as a generic, non-Azure-DevOps LCM entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `executionMethodOverride` property to DSC-Based Resources.
 - Added Datum.yaml LCMConfigurationMode property. Introduced CaC Change Windows.
 - Added `-ContinueOnError` switch to cascade resource failures to dependents while allowing independent resources to continue.
+- Added `Invoke-DscLCM` public function exposing the LCM's generic orchestration logic (Datum compilation, configuration-mode resolution, per-file LCM execution) without any Azure DevOps authentication dependency, enabling non-Azure-DevOps DSC resource modules to use the LCM.
 
 ### Changed
 
 - Replaced "Set" and "Test" modes with "ApplyOnly", "Audit", "Enforce" and "Scheduled"
 - Refactored DSC Resources to be classed-based.
 - LCM will perform an additional 'Test' after 'Set' to validate that setting has been applied correctly.
+- `AzureDevOpsDsc` and `AzureDevOpsDsc.Common` are no longer hard `RequiredModules` for the `azdo-dsc-lcm` module manifest; `Invoke-AZDoLCM` now checks for `AzureDevOpsDsc.Common` at call time instead, so `Import-Module azdo-dsc-lcm` no longer requires them to be installed.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored DSC Resources to be classed-based.
 - LCM will perform an additional 'Test' after 'Set' to validate that setting has been applied correctly.
 - `AzureDevOpsDsc` and `AzureDevOpsDsc.Common` are no longer hard `RequiredModules` for the `azdo-dsc-lcm` module manifest; `Invoke-AZDoLCM` now checks for `AzureDevOpsDsc.Common` at call time instead, so `Import-Module azdo-dsc-lcm` no longer requires them to be installed.
+- The `AZDODSC_CACHE_DIRECTORY` environment variable check moved from the generic `Invoke-DscLCM` to `Invoke-AZDoLCM`, since it's only read by the `AzureDevOpsDsc` resources themselves, not by the LCM engine.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -478,19 +478,16 @@ In the realm of configuration, there are specialized commands designed to modify
 
 The LCM's execution engine (Datum compilation, configuration validation, resource invocation) does not depend on Azure DevOps in any way — it invokes whatever DSC resource module the compiled configuration's `type:` fields reference. `Invoke-AZDoLCM` is a thin, Azure-DevOps-flavored wrapper around this engine: it authenticates to Azure DevOps and then delegates everything else to `Invoke-DscLCM`.
 
-If your configuration targets a different (or no) authenticated backend, call `Invoke-DscLCM` directly. It requires no `AzureDevOpsDsc` or `AzureDevOpsDsc.Common` install, and performs no authentication of its own — authenticate to whatever your configuration's resources require using that module's own mechanism before calling it.
+If your configuration targets a different (or no) authenticated backend, call `Invoke-DscLCM` directly. It requires no `AzureDevOpsDsc` or `AzureDevOpsDsc.Common` install, needs no `AZDODSC_CACHE_DIRECTORY` environment variable (that's only read by the `AzureDevOpsDsc` resources themselves), and performs no authentication of its own — authenticate to whatever your configuration's resources require using that module's own mechanism before calling it.
 
 ```powershell
 Import-Module azdo-dsc-lcm
-
-# Set the cache directory the LCM uses during a run.
-[System.Environment]::SetEnvironmentVariable("AZDODSC_CACHE_DIRECTORY", "C:\AzureDevOpsDSC\Cache")
 
 # Authenticate to whatever DSC resource module your configuration's `type:` fields reference,
 # using that module's own mechanism, before calling Invoke-DscLCM.
 
 $params = @{
-    exportConfigDir         = 'C:\AzureDevOpsDSC\Configuration Export\'
+    exportConfigDir         = 'C:\MyConfig\Export\'
     ConfigurationSourcePath = 'C:\MyConfigRepo'
     ConfigurationMode       = 'Audit'
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@
 
 ## Overview
 
-`AzDO-DSC-LCM` is the Local Configuration Manager (LCM) component for the `AzureDevOpsDsc` DSC Module. This module helps manage Azure DevOps resources through Desired State Configuration (DSC). Utilizes Datum to merge configuration stubs into larger pieces of configuration which is parsed into the LCM.
+`AzDO-DSC-LCM` is a Local Configuration Manager (LCM) for Desired State Configuration (DSC). Its execution engine is resource-agnostic — it invokes whatever DSC resource module a compiled configuration's `type:` fields reference, so it isn't limited to the `AzureDevOpsDsc` DSC Module. It utilizes Datum to merge configuration stubs into larger pieces of configuration which is parsed into the LCM.
+
+Two public entry points build on this same engine:
+
+- `Invoke-AZDoLCM`: the Azure DevOps-flavored entry point. Authenticates to Azure DevOps (Managed Identity or PAT) and is the recommended choice for configurations that manage `AzureDevOpsDsc` resources.
+- `Invoke-DscLCM`: a generic entry point with no Azure DevOps dependency at all — no `AzureDevOpsDsc`/`AzureDevOpsDsc.Common` install required. Use this if your configuration targets other DSC resource modules; authenticate to whatever those resources require using their own mechanism before calling it. See [Using Invoke-DscLCM Directly (Non-Azure DevOps Consumers)](#using-invoke-dsclcm-directly-non-azure-devops-consumers) for details.
 
 ## Datum
 

--- a/README.md
+++ b/README.md
@@ -468,3 +468,28 @@ In the realm of configuration, there are specialized commands designed to modify
         - Monitor logs and outputs for any runtime errors or warnings that could indicate misconfigurations or issues needing resolution.
     - __Verify Expected Outcomes:__
         - Conduct thorough testing to confirm that the LCM behaves as expected, making adjustments as necessary to address any discrepancies or failures.
+
+## Using Invoke-DscLCM Directly (Non-Azure DevOps Consumers)
+
+The LCM's execution engine (Datum compilation, configuration validation, resource invocation) does not depend on Azure DevOps in any way — it invokes whatever DSC resource module the compiled configuration's `type:` fields reference. `Invoke-AZDoLCM` is a thin, Azure-DevOps-flavored wrapper around this engine: it authenticates to Azure DevOps and then delegates everything else to `Invoke-DscLCM`.
+
+If your configuration targets a different (or no) authenticated backend, call `Invoke-DscLCM` directly. It requires no `AzureDevOpsDsc` or `AzureDevOpsDsc.Common` install, and performs no authentication of its own — authenticate to whatever your configuration's resources require using that module's own mechanism before calling it.
+
+```powershell
+Import-Module azdo-dsc-lcm
+
+# Set the cache directory the LCM uses during a run.
+[System.Environment]::SetEnvironmentVariable("AZDODSC_CACHE_DIRECTORY", "C:\AzureDevOpsDSC\Cache")
+
+# Authenticate to whatever DSC resource module your configuration's `type:` fields reference,
+# using that module's own mechanism, before calling Invoke-DscLCM.
+
+$params = @{
+    exportConfigDir         = 'C:\AzureDevOpsDSC\Configuration Export\'
+    ConfigurationSourcePath = 'C:\MyConfigRepo'
+    ConfigurationMode       = 'Audit'
+}
+Invoke-DscLCM @params
+```
+
+`Invoke-AZDoLCM` remains the recommended entry point for Azure DevOps DSC configurations — it now checks for `AzureDevOpsDsc.Common` when called, rather than requiring it at `Import-Module` time, so `Import-Module azdo-dsc-lcm` no longer fails in environments that only need the generic engine.

--- a/Tests/LCM/DSCConfiguration/Public/Invoke-AZDoLCM.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Public/Invoke-AZDoLCM.tests.ps1
@@ -22,6 +22,31 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
         $exportConfigDir = New-MockDirectoryPath
         $ConfigurationSourcePath = New-MockDirectoryPath
 
+        # Most contexts assume this is set; "Environment Variable Check" below covers the unset case.
+        $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
+
+    }
+
+    AfterAll {
+        $Env:AZDODSC_CACHE_DIRECTORY = $null
+    }
+
+    Context "Environment Variable Check" {
+
+        AfterEach {
+            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
+        }
+
+        It "Should throw an error if AZDODSC_CACHE_DIRECTORY environment variable is not set" {
+            Remove-Item Env:AZDODSC_CACHE_DIRECTORY -ErrorAction SilentlyContinue
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script*"
+            Should -Invoke -CommandName Invoke-DscLCM -Exactly 0
+        }
+
+        It "Should not throw an error if AZDODSC_CACHE_DIRECTORY environment variable is set" {
+            $env:AZDODSC_CACHE_DIRECTORY = "SomePath"
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+        }
     }
 
     Context "AzureDevOpsDsc.Common Dependency Check" {

--- a/Tests/LCM/DSCConfiguration/Public/Invoke-AZDoLCM.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Public/Invoke-AZDoLCM.tests.ps1
@@ -3,19 +3,9 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
 
     BeforeAll {
 
-        # Load the functions to test
+        # Load the function to test, and Invoke-DscLCM so its real signature is known before mocking it
         $preParseFilePath = (Get-FunctionPath 'Invoke-AZDoLCM.ps1').FullName
-
-        @(
-            (Get-FunctionPath 'Start-LCM.ps1')
-            (Get-FunctionPath 'Build-DatumConfiguration.ps1')
-            (Get-FunctionPath 'Clone-Repository.ps1')
-            (Get-FunctionPath 'Get-LCMConfigurationMode.ps1')
-            (Get-FunctionPath 'Test-DatumConfiguration.ps1')
-        ) | ForEach-Object {
-            . $_.FullName
-        }
-
+        . (Get-FunctionPath 'Invoke-DscLCM.ps1').FullName
         . $preParseFilePath
 
         # Mock Authentication Provider Function
@@ -23,74 +13,42 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
             param($OrganizationName, $PersonalAccessToken, [switch]$useManagedIdentity)
         }
 
-
-        # Mock necessary commands to prevent actual execution during tests
-        Mock -CommandName Get-DSCResource -MockWith { @{ Version = @{ Major = 2 } } }
-        Mock -CommandName Get-Module -MockWith { @{ Name = 'AzureDevOpsDsc' } }
         Mock -CommandName Import-Module
         Mock -CommandName New-AzDoAuthenticationProvider
-        Mock -CommandName Start-LCM
-        Mock -CommandName Build-DatumConfiguration
-        Mock -CommandName Get-ChildItem -MockWith { @() }
-        Mock -CommandName Split-Path -MockWith {
-            "$TestDrive\MockPath\"
-        }
+        Mock -CommandName Invoke-DscLCM
+        # exportConfigDir's ValidateScript calls the real Test-Path at parameter-binding time.
         Mock -CommandName Test-Path -MockWith { return $true }
-
-        # Invoke-AZDoLCM now always reads and validates datum.yml — mock these globally
-        # so unit tests remain focused on Invoke-AZDoLCM logic rather than datum validation
-        Mock -CommandName Get-Content -MockWith { return "MOCKED DATUM CONTENT" }
-        Mock -CommandName ConvertFrom-Yaml -MockWith {
-            return @{ LCMConfigurationMode = @{ ConfigurationMode = 'Audit'; ChangeWindows = @() } }
-        }
-        Mock -CommandName Test-DatumConfiguration
 
         $exportConfigDir = New-MockDirectoryPath
         $ConfigurationSourcePath = New-MockDirectoryPath
 
     }
 
-    Context "Environment Variable Check" {
+    Context "AzureDevOpsDsc.Common Dependency Check" {
 
-            BeforeAll {
-                Mock -CommandName Test-Path -MockWith { return $true }
-                $Env:AZDODSC_CACHE_DIRECTORY = $null
-            }
-
-            AfterAll {
-                $Env:AZDODSC_CACHE_DIRECTORY = $null
-            }
-
-        It "Should throw an error if AZDODSC_CACHE_DIRECTORY environment variable is not set" {
-            Remove-Item Env:AZDODSC_CACHE_DIRECTORY -ErrorAction SilentlyContinue
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script*"
+        It "Should throw a clear error if AzureDevOpsDsc.Common cannot be imported" {
+            Mock -CommandName Import-Module -MockWith { throw "module not found" }
+            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*AzureDevOpsDsc.Common*"
+            Should -Invoke -CommandName New-AzDoAuthenticationProvider -Exactly 0
+            Should -Invoke -CommandName Invoke-DscLCM -Exactly 0
         }
 
-        It "Should not throw an error if AZDODSC_CACHE_DIRECTORY environment variable is set" {
-            $env:AZDODSC_CACHE_DIRECTORY = "SomePath"
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
-        } 
     }
 
     Context "Execution Logic" {
 
         BeforeAll {
-            Mock -CommandName Test-Path -MockWith { return $true }
-            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
-
             function Get-MockPATToken {
                 param(
                     [int]$Length = 52
                 )
-                
+
                 # Define characters allowed in a PAT token
                 $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-                
+
                 # Generate a random token of specified length
                 -join ((1..$Length) | ForEach-Object { $chars[(Get-Random -Maximum $chars.Length)] })
             }
-            
-
         }
 
        It "Should create authentication provider with ManagedIdentity" {
@@ -104,100 +62,45 @@ Describe "Invoke-AZDoLCM Function Tests" -Tag Unit {
             Assert-MockCalled -CommandName New-AzDoAuthenticationProvider -Exactly 1 -Scope It -ParameterFilter { $PersonalAccessToken -eq $PAT }
        }
 
-       It "Should build datum configuration" {
+    }
+
+    Context "Delegation to Invoke-DscLCM" {
+
+        It "Should delegate to Invoke-DscLCM with the correct parameters" {
+            # ParameterFilter binds Invoke-DscLCM's own bound parameters as local variables,
+            # which would shadow same-named outer variables — capture expected values under
+            # different names first so the comparison isn't a tautology.
+            $expectedExportDir = $exportConfigDir
+            $expectedSourcePath = $ConfigurationSourcePath
+
             Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath
-            Assert-MockCalled -CommandName Build-DatumConfiguration -Exactly 1 -Scope It
-       }
-    }
-
-    Context "When testing -ConfigurationSourcePath" {
-
-        BeforeAll {
-            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
-        }
-
-        AfterAll {
-            $Env:AZDODSC_CACHE_DIRECTORY = $null
-        }
-
-        it "should call Clone-Repository with a valid URL" {
-            Mock -CommandName 'Clone-Repository' -Verifiable -MockWith {
-                return '\mockPath'
+            Should -Invoke -CommandName Invoke-DscLCM -Exactly 1 -ParameterFilter {
+                $exportConfigDir -eq $expectedExportDir -and
+                $ConfigurationSourcePath -eq $expectedSourcePath -and
+                $ConfigurationMode -eq 'Audit'
             }
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath "http://mockGitRepo.com/repo"} | Should -Not -Throw
-            Should -InvokeVerifiable
         }
 
-        it "should parse a valid file path if it isn't a valid URL" {
-            Mock -CommandName 'Clone-Repository'
-            Mock -CommandName 'Test-Path' -ParameterFilter {
-                $path -eq $exportConfigDir
-            } -Verifiable -MockWith { return $true }
-
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
-            Should -Invoke 'Clone-Repository' -Exactly 0
-            Should -InvokeVerifiable
-            Should -Invoke 'Start-LCM' -Exactly 0
-
+        It "Should omit ConfigurationMode from the delegated call when not supplied" {
+            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationSourcePath $ConfigurationSourcePath
+            Should -Invoke -CommandName Invoke-DscLCM -Exactly 1 -ParameterFilter {
+                [string]::IsNullOrEmpty($ConfigurationMode)
+            }
         }
 
-        it "should throw an error if it's neither a valid URL or FilePath" {
-
-            Mock -CommandName 'Clone-Repository'
-            Mock -CommandName 'Test-Path' -ParameterFilter {
-                $path -eq $ConfigurationSourcePath
-            } -Verifiable -MockWith { return $false }
-
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*Invalid ConfigurationSourcePath*"
-            Should -Invoke 'Clone-Repository' -Exactly 0
-            Should -InvokeVerifiable
-            Should -Invoke 'Start-LCM' -Exactly 0            
-
+        It "Should pass through ContinueOnError and ReportPath when supplied" {
+            $expectedReportPath = $exportConfigDir
+            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath -ReportPath $exportConfigDir -ContinueOnError
+            Should -Invoke -CommandName Invoke-DscLCM -Exactly 1 -ParameterFilter {
+                $ReportPath -eq $expectedReportPath -and $ContinueOnError -eq $true
+            }
         }
 
-
-
-    }
-
-    Context "When testing -ConfigurationMode" {
-
-        BeforeAll {
-            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
-            mock -CommandName 'Get-ChildItem' -MockWith { @(
-                [PSCustomObject]@{ Fullname = "$TestDrive\mockConfig.yml" }
-            ) }
-        }
-
-        AfterAll {
-            $Env:AZDODSC_CACHE_DIRECTORY = $null
-        }
-
-        it "should call Start-LCM with the specified ConfigurationMode" {
-            Mock -CommandName 'Start-LCM' -MockWith { return $true } -Verifiable
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
-            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter {  $ConfigurationMode -eq 'Audit' }
-            Should -InvokeVerifiable
-        }
-
-        it "should throw an error if an invalid ConfigurationMode is provided" {
-            Mock -CommandName 'Start-LCM'
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "InvalidMode" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*Cannot validate argument on parameter 'ConfigurationMode'*"
-            Should -Invoke 'Start-LCM' -Exactly 0
-        }
-
-        it "should call 'ConvertFrom-Yaml' and 'Get-LCMConfigurationMode' if ConfigurationMode is not provided" {
-            Mock -CommandName 'Get-Content' -Verifiable -MockWith { return "MOCKED CONTENT" }
-            Mock -CommandName 'ConvertFrom-Yaml' -Verifiable -MockWith { return @{ LCMConfigurationMode = @{ ConfigurationMode = 'Scheduled'; ChangeWindows = @() } } }
-            Mock -CommandName 'Get-LCMConfigurationMode' -Verifiable -MockWith { return 'Audit' }
-            Mock -CommandName 'Start-LCM' -Verifiable -MockWith { return $true }
-
-            { Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
-
-            Should -Invoke 'ConvertFrom-Yaml' -Exactly 1
-            Should -Invoke 'Get-LCMConfigurationMode' -Exactly 1
-            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter { $ConfigurationMode -eq 'Audit' }
-
-            Should -InvokeVerifiable
+        It "Should not pass ReportPath or ContinueOnError when not supplied" {
+            Invoke-AZDoLCM -AzureDevopsOrganizationName "MyOrg" -exportConfigDir $exportConfigDir -JITToken "abc123" -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath
+            Should -Invoke -CommandName Invoke-DscLCM -Exactly 1 -ParameterFilter {
+                [string]::IsNullOrEmpty($ReportPath) -and $ContinueOnError -ne $true
+            }
         }
 
     }

--- a/Tests/LCM/DSCConfiguration/Public/Invoke-DscLCM.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Public/Invoke-DscLCM.tests.ps1
@@ -1,0 +1,170 @@
+
+Describe "Invoke-DscLCM Function Tests" -Tag Unit {
+
+    BeforeAll {
+
+        # Load the functions to test
+        $preParseFilePath = (Get-FunctionPath 'Invoke-DscLCM.ps1').FullName
+
+        @(
+            (Get-FunctionPath 'Start-LCM.ps1')
+            (Get-FunctionPath 'Build-DatumConfiguration.ps1')
+            (Get-FunctionPath 'Clone-Repository.ps1')
+            (Get-FunctionPath 'Get-LCMConfigurationMode.ps1')
+            (Get-FunctionPath 'Test-DatumConfiguration.ps1')
+        ) | ForEach-Object {
+            . $_.FullName
+        }
+
+        . $preParseFilePath
+
+        # Mock necessary commands to prevent actual execution during tests
+        Mock -CommandName Start-LCM
+        Mock -CommandName Build-DatumConfiguration
+        Mock -CommandName Get-ChildItem -MockWith { @() }
+        Mock -CommandName Split-Path -MockWith {
+            "$TestDrive\MockPath\"
+        }
+        Mock -CommandName Test-Path -MockWith { return $true }
+
+        # Invoke-DscLCM always reads and validates datum.yml — mock these globally
+        # so unit tests remain focused on Invoke-DscLCM logic rather than datum validation
+        Mock -CommandName Get-Content -MockWith { return "MOCKED DATUM CONTENT" }
+        Mock -CommandName ConvertFrom-Yaml -MockWith {
+            return @{ LCMConfigurationMode = @{ ConfigurationMode = 'Audit'; ChangeWindows = @() } }
+        }
+        Mock -CommandName Test-DatumConfiguration
+
+        $exportConfigDir = New-MockDirectoryPath
+        $ConfigurationSourcePath = New-MockDirectoryPath
+
+    }
+
+    Context "Environment Variable Check" {
+
+            BeforeAll {
+                Mock -CommandName Test-Path -MockWith { return $true }
+                $Env:AZDODSC_CACHE_DIRECTORY = $null
+            }
+
+            AfterAll {
+                $Env:AZDODSC_CACHE_DIRECTORY = $null
+            }
+
+        It "Should throw an error if AZDODSC_CACHE_DIRECTORY environment variable is not set" {
+            Remove-Item Env:AZDODSC_CACHE_DIRECTORY -ErrorAction SilentlyContinue
+            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script*"
+        }
+
+        It "Should not throw an error if AZDODSC_CACHE_DIRECTORY environment variable is set" {
+            $env:AZDODSC_CACHE_DIRECTORY = "SomePath"
+            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+        }
+    }
+
+    Context "Execution Logic" {
+
+        BeforeAll {
+            Mock -CommandName Test-Path -MockWith { return $true }
+            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
+        }
+
+       It "Should build datum configuration" {
+            Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath
+            Assert-MockCalled -CommandName Build-DatumConfiguration -Exactly 1 -Scope It
+       }
+    }
+
+    Context "When testing -ConfigurationSourcePath" {
+
+        BeforeAll {
+            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
+        }
+
+        AfterAll {
+            $Env:AZDODSC_CACHE_DIRECTORY = $null
+        }
+
+        it "should call Clone-Repository with a valid URL" {
+            Mock -CommandName 'Clone-Repository' -Verifiable -MockWith {
+                return '\mockPath'
+            }
+            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath "http://mockGitRepo.com/repo"} | Should -Not -Throw
+            Should -InvokeVerifiable
+        }
+
+        it "should parse a valid file path if it isn't a valid URL" {
+            Mock -CommandName 'Clone-Repository'
+            Mock -CommandName 'Test-Path' -ParameterFilter {
+                $path -eq $exportConfigDir
+            } -Verifiable -MockWith { return $true }
+
+            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+            Should -Invoke 'Clone-Repository' -Exactly 0
+            Should -InvokeVerifiable
+            Should -Invoke 'Start-LCM' -Exactly 0
+
+        }
+
+        it "should throw an error if it's neither a valid URL or FilePath" {
+
+            Mock -CommandName 'Clone-Repository'
+            Mock -CommandName 'Test-Path' -ParameterFilter {
+                $path -eq $ConfigurationSourcePath
+            } -Verifiable -MockWith { return $false }
+
+            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*Invalid ConfigurationSourcePath*"
+            Should -Invoke 'Clone-Repository' -Exactly 0
+            Should -InvokeVerifiable
+            Should -Invoke 'Start-LCM' -Exactly 0
+
+        }
+
+
+
+    }
+
+    Context "When testing -ConfigurationMode" {
+
+        BeforeAll {
+            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
+            mock -CommandName 'Get-ChildItem' -MockWith { @(
+                [PSCustomObject]@{ Fullname = "$TestDrive\mockConfig.yml" }
+            ) }
+        }
+
+        AfterAll {
+            $Env:AZDODSC_CACHE_DIRECTORY = $null
+        }
+
+        it "should call Start-LCM with the specified ConfigurationMode" {
+            Mock -CommandName 'Start-LCM' -MockWith { return $true } -Verifiable
+            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter {  $ConfigurationMode -eq 'Audit' }
+            Should -InvokeVerifiable
+        }
+
+        it "should throw an error if an invalid ConfigurationMode is provided" {
+            Mock -CommandName 'Start-LCM'
+            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "InvalidMode" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*Cannot validate argument on parameter 'ConfigurationMode'*"
+            Should -Invoke 'Start-LCM' -Exactly 0
+        }
+
+        it "should call 'ConvertFrom-Yaml' and 'Get-LCMConfigurationMode' if ConfigurationMode is not provided" {
+            Mock -CommandName 'Get-Content' -Verifiable -MockWith { return "MOCKED CONTENT" }
+            Mock -CommandName 'ConvertFrom-Yaml' -Verifiable -MockWith { return @{ LCMConfigurationMode = @{ ConfigurationMode = 'Scheduled'; ChangeWindows = @() } } }
+            Mock -CommandName 'Get-LCMConfigurationMode' -Verifiable -MockWith { return 'Audit' }
+            Mock -CommandName 'Start-LCM' -Verifiable -MockWith { return $true }
+
+            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
+
+            Should -Invoke 'ConvertFrom-Yaml' -Exactly 1
+            Should -Invoke 'Get-LCMConfigurationMode' -Exactly 1
+            Should -Invoke 'Start-LCM' -Exactly 1 -ParameterFilter { $ConfigurationMode -eq 'Audit' }
+
+            Should -InvokeVerifiable
+        }
+
+    }
+
+}

--- a/Tests/LCM/DSCConfiguration/Public/Invoke-DscLCM.tests.ps1
+++ b/Tests/LCM/DSCConfiguration/Public/Invoke-DscLCM.tests.ps1
@@ -40,33 +40,10 @@ Describe "Invoke-DscLCM Function Tests" -Tag Unit {
 
     }
 
-    Context "Environment Variable Check" {
-
-            BeforeAll {
-                Mock -CommandName Test-Path -MockWith { return $true }
-                $Env:AZDODSC_CACHE_DIRECTORY = $null
-            }
-
-            AfterAll {
-                $Env:AZDODSC_CACHE_DIRECTORY = $null
-            }
-
-        It "Should throw an error if AZDODSC_CACHE_DIRECTORY environment variable is not set" {
-            Remove-Item Env:AZDODSC_CACHE_DIRECTORY -ErrorAction SilentlyContinue
-            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Throw "*The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script*"
-        }
-
-        It "Should not throw an error if AZDODSC_CACHE_DIRECTORY environment variable is set" {
-            $env:AZDODSC_CACHE_DIRECTORY = "SomePath"
-            { Invoke-DscLCM -exportConfigDir $exportConfigDir -ConfigurationMode "Audit" -ConfigurationSourcePath $ConfigurationSourcePath } | Should -Not -Throw
-        }
-    }
-
     Context "Execution Logic" {
 
         BeforeAll {
             Mock -CommandName Test-Path -MockWith { return $true }
-            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
         }
 
        It "Should build datum configuration" {
@@ -76,14 +53,6 @@ Describe "Invoke-DscLCM Function Tests" -Tag Unit {
     }
 
     Context "When testing -ConfigurationSourcePath" {
-
-        BeforeAll {
-            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
-        }
-
-        AfterAll {
-            $Env:AZDODSC_CACHE_DIRECTORY = $null
-        }
 
         it "should call Clone-Repository with a valid URL" {
             Mock -CommandName 'Clone-Repository' -Verifiable -MockWith {
@@ -127,14 +96,9 @@ Describe "Invoke-DscLCM Function Tests" -Tag Unit {
     Context "When testing -ConfigurationMode" {
 
         BeforeAll {
-            $Env:AZDODSC_CACHE_DIRECTORY = "mocked"
             mock -CommandName 'Get-ChildItem' -MockWith { @(
                 [PSCustomObject]@{ Fullname = "$TestDrive\mockConfig.yml" }
             ) }
-        }
-
-        AfterAll {
-            $Env:AZDODSC_CACHE_DIRECTORY = $null
         }
 
         it "should call Start-LCM with the specified ConfigurationMode" {

--- a/source/Public/Invoke-AZDoLCM.ps1
+++ b/source/Public/Invoke-AZDoLCM.ps1
@@ -106,6 +106,15 @@ function Invoke-AzDoLCM {
     $ErrorActionPreference = "Stop"
 
     #
+    # Test to make sure that the Enviroment Variable is Set.
+    # The AzureDevOpsDsc resources read this at execution time; the generic Invoke-DscLCM
+    # engine has no use for it, so this check lives here rather than in Invoke-DscLCM.
+
+    if (-not $ENV:AZDODSC_CACHE_DIRECTORY) {
+        throw "The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script."
+    }
+
+    #
     # Ensure the Azure DevOps-specific auth dependency is available before doing anything else.
 
     try {

--- a/source/Public/Invoke-AZDoLCM.ps1
+++ b/source/Public/Invoke-AZDoLCM.ps1
@@ -3,7 +3,9 @@
 Invokes the Azure DevOps Lifecycle Management (LCM) process using specified configurations and authentication methods.
 
 .DESCRIPTION
-The Invoke-AZDoLCM function is designed to manage the lifecycle of Azure DevOps configurations. It supports advanced function features similar to cmdlets and allows for different authentication methods, including Managed Identity and Personal Access Token (PAT). The function handles the cloning of configuration repositories, compilation of configurations, and invocation of resources based on the provided parameters.
+The Invoke-AZDoLCM function is designed to manage the lifecycle of Azure DevOps configurations. It supports advanced function features similar to cmdlets and allows for different authentication methods, including Managed Identity and Personal Access Token (PAT). It authenticates to Azure DevOps and then delegates configuration compilation and resource invocation to Invoke-DscLCM.
+
+This function requires the AzureDevOpsDsc.Common module to be installed. If your configuration does not need Azure DevOps authentication, call Invoke-DscLCM directly instead.
 
 .PARAMETER AzureDevopsOrganizationName
 Specifies the name of the Azure DevOps organization. This parameter is mandatory.
@@ -104,36 +106,13 @@ function Invoke-AzDoLCM {
     $ErrorActionPreference = "Stop"
 
     #
-    # Get the Execution Path
-    #$ExecutionPath = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+    # Ensure the Azure DevOps-specific auth dependency is available before doing anything else.
 
-    #
-    # Test to make sure that the Enviroment Variable is Set
-
-    if (-not $ENV:AZDODSC_CACHE_DIRECTORY) {
-        throw "The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script."
+    try {
+        Import-Module -Name 'AzureDevOpsDsc.Common' -ErrorAction Stop
+    } catch {
+        throw "[Invoke-AZDoLCM] Required module 'AzureDevOpsDsc.Common' is not available. Install it via 'Install-Module AzureDevOpsDsc.Common' before calling Invoke-AZDoLCM, or call Invoke-DscLCM directly if Azure DevOps authentication is not required. Underlying error: $($_.Exception.Message)"
     }
-
-    #
-    # Clone the Datum Configuration from the Configuration URL
-
-    # Test ConfigurationSourcePath if it is a URL. If URL attempt to clone.
-    if ($ConfigurationSourcePath -match '^(http|https):\/\/') {
-        # Cone from URL
-        $DatumConfigurationPath = Clone-Repository -DatumURLConfig $ConfigurationSourcePath
-    }
-    # Test if ConfigurationSourcePath is a directory path that exists.
-    elseif (Test-Path -Path $ConfigurationSourcePath -PathType Container) {
-        $DatumConfigurationPath = $ConfigurationSourcePath
-    } 
-    # Else. Throw an error for bad data.
-    else {
-        throw "[Invoke-LCM] Invalid ConfigurationSourcePath: $ConfigurationSourcePath"
-    }
-
-    #
-    # Compile the Datum Configuration
-    Build-DatumConfiguration -OutputPath $exportConfigDir -ConfigurationPath $DatumConfigurationPath
 
     #
     # Determine the Authentication Type and create the Authentication Provider
@@ -142,132 +121,28 @@ function Invoke-AzDoLCM {
         New-AzDoAuthenticationProvider -OrganizationName $AzureDevopsOrganizationName -PersonalAccessToken $PATToken
     } elseif ($AuthenticationType -eq 'ManagedIdentity') {
         New-AzDoAuthenticationProvider -OrganizationName $AzureDevopsOrganizationName -useManagedIdentity
-    } #else {
-    #    throw "The Authentication Type $AuthenticationType is not supported. Please use either 'PAT' or 'ManagedIdentity'."
-    #}
-
-    #
-    # Read and validate the Datum Configuration
-
-    $DatumConfiguration = Get-Content -Path (Join-Path $DatumConfigurationPath 'datum.yml') | ConvertFrom-Yaml
-    Test-DatumConfiguration -Datum @{ '__Definition' = $DatumConfiguration }
-
-    #
-    # Determine the LCM Configuration Mode
-
-    # If the ConfigurationMode parameter is provided, use it. Otherwise, determine the mode from the Datum Configuration.
-    if (-not $ConfigurationMode) {
-        $ConfigurationMode = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfiguration.LCMConfigurationMode
     }
 
     #
-    # Invoke the Resources
+    # Delegate configuration compilation and resource invocation to the generic entry point.
 
-    # Create a hashtable to store the parameters
     $params = @{
-        ConfigurationMode = $ConfigurationMode
-        DSCCompositeResourcePath = Join-Path $DatumConfigurationPath 'CompositeResources'
+        exportConfigDir         = $exportConfigDir
+        ConfigurationSourcePath = $ConfigurationSourcePath
     }
 
-    # If the ReportPath is provided, add it to the parameters
+    if ($ConfigurationMode) {
+        $params.ConfigurationMode = $ConfigurationMode
+    }
+
     if ($ReportPath) {
         $params.ReportPath = $ReportPath
     }
 
-    # Pass ContinueOnError through to each LCM run
     if ($ContinueOnError) {
         $params.ContinueOnError = $true
     }
 
-    Get-ChildItem -LiteralPath $exportConfigDir -File -Filter "*.yml" | ForEach-Object {
-        Start-LCM -FilePath $_.Fullname @params
-    }
-
-    <#
-    return
-
-    $postExecutionConfiguration = [System.Collections.Generic.List[HashTable]]::new()
-    # Once Completed, Iterate through the Output Directory and run the post execution tasks.
-    Get-ChildItem -LiteralPath $DatumConfigurationPath -File -Filter "*.yml" | ForEach-Object {
-
-        # Load the Configuration Files
-        $configuration = Get-Content $_.FullName | ConvertFrom-Yaml
-        
-        # Create a Hash Table to store the Post Execution Tasks.
-        # Include the Post Execution Tasks and Variables.
-        # The Variables are used to pass the variables to the Post Execution Tasks.
-
-        $hashTable = @{
-            postExecution = $configuration.resources
-            variables = $configuration.variables
-        }
-
-        # Add the Post Execution Tasks to the Configuration Files
-        if ($configuration.resources) {
-            $postExecutionConfiguration.Add($hashTable)
-        }
-
-        # ^\{(.+)\}$
-
-    }
-
-    <#
-    postExecutionTask:
-
-    - name: Org Group Members
-        type: AzureDevOpsDsc/AzDoProject
-        properties:
-        projectName: CON_$ProjectName
-        projectDescription: $ProjectDescription
-        visibility: private
-        SourceControlType: Git
-        ProcessTemplate: { scriptblock }     
-
-
-    #
-
-    #
-    # Flatten the Post Execution Tasks By Caculated Property
-    # Group the Post Execution Tasks by the Name and Type
-
-    $Configuration = $postExecutionConfiguration | ForEach-Object {
-        $_.postExecution | ForEach-Object {
-            $_
-        }
-    } | Group-Object -Property {
-        ("{0}/{1}" -f $_.type, $_.Name)
-    }
-
-    # Once the Post Execution Tasks are collected, iterate through the Post Execution Tasks and group them according to the Task Type.
-    # Iterate thorugh the Grouped Tasks and add the associated variables to the Post Execution Task.
-
-    $groupedPostExecutionTasks = [System.Collections.Generic.List[HashTable]]::new()
-
-    $Configuration | ForEach-Object {
-
-        $currentObject = $_.Group[0]
-        $name = $_.Name
-        $obj = @{
-            name = $name
-            postExecution = $currentObject
-            variables = [System.Collections.Generic.List[hashtable]]::new()
-        }
-
-        # Test if name exists within the postExecutionConfiguration
-        $postExecutionConfiguration | ForEach-Object {
-            $currentObj = $_
-            $matched = $currentObj.postExecution | Where-Object { "$($_.type)/$($_.name)" -eq $name } 
-
-            if ($matched) {
-                $obj.variables.Add($currentObj.variables)
-            }
-
-        }
-
-        $groupedPostExecutionTasks.Add($obj)
-
-    }
-
-    #>
+    Invoke-DscLCM @params
 
 }

--- a/source/Public/Invoke-DscLCM.ps1
+++ b/source/Public/Invoke-DscLCM.ps1
@@ -1,0 +1,126 @@
+<#
+.SYNOPSIS
+Invokes the Local Configuration Manager (LCM) against a Datum configuration source, independent of any specific DSC resource module.
+
+.DESCRIPTION
+The Invoke-DscLCM function compiles a Datum configuration source, validates it, resolves the LCM Configuration Mode, and invokes Start-LCM against every exported configuration file.
+
+Unlike Invoke-AZDoLCM, this function performs no authentication of its own. If the resources referenced by your configuration's `type:` fields require an authenticated connection (for example, DSC resources that call out to a remote service), authenticate using that resource module's own mechanism before calling this function.
+
+.PARAMETER exportConfigDir
+Specifies the directory where configuration files are exported by Datum. This parameter is mandatory and must be a valid directory path.
+
+.PARAMETER ConfigurationSourcePath
+Specifies the URL or directory path for the configuration source. This parameter is mandatory.
+
+.PARAMETER ConfigurationMode
+Specifies the Local Configuration Manager (LCM) mode to use. Valid values are 'ApplyOnly', 'Audit', and 'Enforce'. This parameter is optional; if not provided, the mode will be determined from the Datum configuration.
+
+.PARAMETER ReportPath
+Specifies the path to the report file. This parameter is optional and must be a valid directory path.
+
+.PARAMETER ContinueOnError
+When specified, a resource Set failure does not halt the LCM run. Instead, resources that directly or transitively depend on the failed resource are automatically skipped; all others continue normally.
+
+.EXAMPLE
+Invoke-DscLCM -exportConfigDir "C:\Configs" -ConfigurationSourcePath "https://repo.url" -ConfigurationMode "Audit"
+
+This example compiles and runs the configuration in 'Audit' mode.
+
+.NOTES
+Ensure that the environment variable AZDODSC_CACHE_DIRECTORY is set before running this function. The function will throw an error if this environment variable is not set.
+
+#>
+
+function Invoke-DscLCM {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path -LiteralPath $_ -PathType Container })]
+        [String]$exportConfigDir,
+
+        [Parameter(Mandatory)]
+        [String]$ConfigurationSourcePath,
+
+        [Parameter()]
+        [ValidateSet("ApplyOnly", "Audit", "Enforce")]
+        [AllowEmptyString()]
+        [String]$ConfigurationMode,
+
+        [Parameter()]
+        [ValidateScript({Test-Path -Path $_ -PathType Container})]
+        [String]$ReportPath,
+
+        [Parameter()]
+        [Switch]$ContinueOnError
+    )
+
+    # Set the Error Action Preference
+    $ErrorActionPreference = "Stop"
+
+    #
+    # Test to make sure that the Enviroment Variable is Set
+
+    if (-not $ENV:AZDODSC_CACHE_DIRECTORY) {
+        throw "The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script."
+    }
+
+    #
+    # Clone the Datum Configuration from the Configuration URL
+
+    # Test ConfigurationSourcePath if it is a URL. If URL attempt to clone.
+    if ($ConfigurationSourcePath -match '^(http|https):\/\/') {
+        # Cone from URL
+        $DatumConfigurationPath = Clone-Repository -DatumURLConfig $ConfigurationSourcePath
+    }
+    # Test if ConfigurationSourcePath is a directory path that exists.
+    elseif (Test-Path -Path $ConfigurationSourcePath -PathType Container) {
+        $DatumConfigurationPath = $ConfigurationSourcePath
+    }
+    # Else. Throw an error for bad data.
+    else {
+        throw "[Invoke-DscLCM] Invalid ConfigurationSourcePath: $ConfigurationSourcePath"
+    }
+
+    #
+    # Compile the Datum Configuration
+    Build-DatumConfiguration -OutputPath $exportConfigDir -ConfigurationPath $DatumConfigurationPath
+
+    #
+    # Read and validate the Datum Configuration
+
+    $DatumConfiguration = Get-Content -Path (Join-Path $DatumConfigurationPath 'datum.yml') | ConvertFrom-Yaml
+    Test-DatumConfiguration -Datum @{ '__Definition' = $DatumConfiguration }
+
+    #
+    # Determine the LCM Configuration Mode
+
+    # If the ConfigurationMode parameter is provided, use it. Otherwise, determine the mode from the Datum Configuration.
+    if (-not $ConfigurationMode) {
+        $ConfigurationMode = Get-LCMConfigurationMode -DatumConfigurationMode $DatumConfiguration.LCMConfigurationMode
+    }
+
+    #
+    # Invoke the Resources
+
+    # Create a hashtable to store the parameters
+    $params = @{
+        ConfigurationMode = $ConfigurationMode
+        DSCCompositeResourcePath = Join-Path $DatumConfigurationPath 'CompositeResources'
+    }
+
+    # If the ReportPath is provided, add it to the parameters
+    if ($ReportPath) {
+        $params.ReportPath = $ReportPath
+    }
+
+    # Pass ContinueOnError through to each LCM run
+    if ($ContinueOnError) {
+        $params.ContinueOnError = $true
+    }
+
+    Get-ChildItem -LiteralPath $exportConfigDir -File -Filter "*.yml" | ForEach-Object {
+        Start-LCM -FilePath $_.Fullname @params
+    }
+
+}

--- a/source/Public/Invoke-DscLCM.ps1
+++ b/source/Public/Invoke-DscLCM.ps1
@@ -27,9 +27,6 @@ Invoke-DscLCM -exportConfigDir "C:\Configs" -ConfigurationSourcePath "https://re
 
 This example compiles and runs the configuration in 'Audit' mode.
 
-.NOTES
-Ensure that the environment variable AZDODSC_CACHE_DIRECTORY is set before running this function. The function will throw an error if this environment variable is not set.
-
 #>
 
 function Invoke-DscLCM {
@@ -57,13 +54,6 @@ function Invoke-DscLCM {
 
     # Set the Error Action Preference
     $ErrorActionPreference = "Stop"
-
-    #
-    # Test to make sure that the Enviroment Variable is Set
-
-    if (-not $ENV:AZDODSC_CACHE_DIRECTORY) {
-        throw "The Environment Variable AZDODSC_CACHE_DIRECTORY is not set. Please set the environment variable before running this script."
-    }
 
     #
     # Clone the Datum Configuration from the Configuration URL

--- a/source/template.ps1
+++ b/source/template.ps1
@@ -61,14 +61,6 @@
             MaximumVersion = '1.0.0'
         }
         @{
-            ModuleName = 'AzureDevOpsDsc.Common'
-            MaximumVersion = '1.0.0'
-        }
-        @{
-            ModuleName = 'AzureDevOpsDsc'
-            MaximumVersion = '1.0.0'
-        }
-        @{
             ModuleName = 'datum'
             MaximumVersion = '1.0.0'
         }
@@ -100,6 +92,7 @@
     CmdletsToExport = @(
         'Build-DatumConfiguration'
         'Invoke-AZDoLCM'
+        'Invoke-DscLCM'
         'Resolve-AzDoDatumProject'
         'Stop-TaskProcessing'
         'Test-DatumConfiguration'


### PR DESCRIPTION
## Summary
- Extracts the LCM's core engine (Datum compilation, configuration validation, mode resolution, per-file `Start-LCM` invocation) out of `Invoke-AZDoLCM` into a new public function, `Invoke-DscLCM`, which has no Azure DevOps dependency.
- `Invoke-AZDoLCM` is now a thin wrapper: it checks for `AzureDevOpsDsc.Common`, authenticates to Azure DevOps, then delegates to `Invoke-DscLCM`.
- Moves the `AZDODSC_CACHE_DIRECTORY` environment variable check from the generic engine into `Invoke-AZDoLCM`, since only `AzureDevOpsDsc` resources read it — the engine itself has no use for it.
- Documents (README, CHANGELOG) that the LCM engine is resource-agnostic and works with any DSC resource module, not just `AzureDevOpsDsc`, and adds a "Using Invoke-DscLCM Directly" section with a usage example for non-Azure-DevOps consumers.
- Removes a large block of dead/commented-out post-execution-task code from `Invoke-AZDoLCM.ps1`.

## Why
Consumers whose configurations target other DSC resource modules previously had no way to use the LCM without pulling in Azure DevOps-specific dependencies (`AzureDevOpsDsc.Common`) and authentication requirements. `Invoke-DscLCM` lets them call the same underlying engine directly, authenticating however their own resources require.

## Test plan
- [x] Updated/added Pester tests: `Invoke-AZDoLCM.tests.ps1` (reduced/refactored to test the thinner wrapper) and new `Invoke-DscLCM.tests.ps1`
- [ ] Run the module's Pester test suite
